### PR TITLE
[CORE-70] Implement initial approach to QUARANTINE_END functionality

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -105,6 +105,11 @@
 			<version>4.5</version>
 		</dependency>
 		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.10.6</version>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/src/main/java/quarano/actions/ActionItem.java
+++ b/backend/src/main/java/quarano/actions/ActionItem.java
@@ -83,7 +83,7 @@ public abstract class ActionItem extends QuaranoAggregate<ActionItem, ActionItem
 
 		MEDICAL_INCIDENT,
 
-		PROCESS_INCIDENT;
+		PROCESS_INCIDENT,
 	}
 
 	@Embeddable

--- a/backend/src/main/java/quarano/actions/ActionItemRepository.java
+++ b/backend/src/main/java/quarano/actions/ActionItemRepository.java
@@ -37,4 +37,9 @@ public interface ActionItemRepository extends QuaranoRepository<ActionItem, Acti
 			+ " where i.slot = :slot" //
 			+ " and i.personIdentifier = :personIdentifier")
 	ActionItems findDiaryEntryMissingActionItemsFor(TrackedPersonIdentifier personIdentifier, Slot slot);
+
+	@Query("select i from QuarantineEndingActionItem i" //
+			+ " where i.personIdentifier = :personIdentifier")
+	ActionItems findQuarantineEndingActionItemsFor(TrackedPersonIdentifier personIdentifier);
+
 }

--- a/backend/src/main/java/quarano/actions/ActionItems.java
+++ b/backend/src/main/java/quarano/actions/ActionItems.java
@@ -62,6 +62,12 @@ public class ActionItems implements Streamable<ActionItem> {
 				.anyMatch(ActionItem::isUnresolved);
 	}
 
+	public boolean isEmpty() {
+
+		return items.stream() //
+				.findAny().isEmpty();
+	}
+
 	public boolean hasUnresolvedItemsForManualResolution() {
 
 		return items.stream() //

--- a/backend/src/main/java/quarano/actions/DescriptionCode.java
+++ b/backend/src/main/java/quarano/actions/DescriptionCode.java
@@ -15,6 +15,8 @@ public enum DescriptionCode {
 
 	DIARY_ENTRY_MISSING(true),
 
+	QUARANTINE_ENDING(true),
+
 	MISSING_DETAILS_INDEX(false),
 
 	MISSING_DETAILS_CONTACT(false),
@@ -26,7 +28,7 @@ public enum DescriptionCode {
 	private final @Getter float multiplier;
 	private final @Getter boolean manuallyResolvable;
 
-	private DescriptionCode(boolean manuallyResolvable) {
+	DescriptionCode(boolean manuallyResolvable) {
 		this(1f, manuallyResolvable);
 	}
 }

--- a/backend/src/main/java/quarano/actions/DiaryEventListener.java
+++ b/backend/src/main/java/quarano/actions/DiaryEventListener.java
@@ -18,7 +18,7 @@ public class DiaryEventListener {
 	private final ActionItemRepository items;
 
 	@EventListener
-	void onDiaryEntryAddedToResolveMissingItems(DiaryEntryAdded event) {
+	public void onDiaryEntryAddedToResolveMissingItems(DiaryEntryAdded event) {
 
 		var entry = event.getEntry();
 		var person = entry.getTrackedPersonId();
@@ -30,7 +30,7 @@ public class DiaryEventListener {
 	}
 
 	@EventListener
-	void onDiaryEntryAddedForBodyTemperature(DiaryEntryAdded event) {
+	public void onDiaryEntryAddedForBodyTemperature(DiaryEntryAdded event) {
 
 		var entry = event.getEntry();
 		var person = entry.getTrackedPersonId();
@@ -50,7 +50,7 @@ public class DiaryEventListener {
 	}
 
 	@EventListener
-	void onDiaryEntryAddedForCharacteristicSymptoms(DiaryEntryAdded event) {
+	public void onDiaryEntryAddedForCharacteristicSymptoms(DiaryEntryAdded event) {
 
 		var entry = event.getEntry();
 		var person = entry.getTrackedPersonId();
@@ -66,7 +66,7 @@ public class DiaryEventListener {
 	}
 
 	@EventListener
-	void on(DiaryEntryMissing diaryEntryMissing) {
+	public void on(DiaryEntryMissing diaryEntryMissing) {
 
 		log.debug("Caught diaryEntryMissing Event {}. Save it as DiaryEntryMissingActionItem", diaryEntryMissing);
 

--- a/backend/src/main/java/quarano/actions/quarantine/QuarantineEndChecker.java
+++ b/backend/src/main/java/quarano/actions/quarantine/QuarantineEndChecker.java
@@ -1,0 +1,50 @@
+package quarano.actions.quarantine;
+
+import static quarano.department.TrackedCase.Status.OPEN;
+
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTime;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import quarano.actions.ActionItemRepository;
+import quarano.department.TrackedCase;
+import quarano.department.TrackedCaseRepository;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class QuarantineEndChecker {
+
+	private final TrackedCaseRepository trackedCases;
+	private final ActionItemRepository items;
+
+	@Scheduled(cron = "0 8 * * *")
+	public void checkEndingQuarantinesPeriodically() {
+		List<TrackedCase> endingQuarantineCases = getEndingQuarantineCases();
+		createActionItems(endingQuarantineCases);
+	}
+
+	private void createActionItems(List<TrackedCase> endingQuarantineCases) {
+		endingQuarantineCases.stream()
+				.filter(trackedCase -> items.findQuarantineEndingActionItemsFor(trackedCase.getTrackedPerson().getId()).isEmpty())
+				.map(trackedCase -> new QuarantineEndingActionItem(trackedCase.getTrackedPerson().getId()))
+				.forEach(items::save);
+	}
+
+	private List<TrackedCase> getEndingQuarantineCases() {
+		return trackedCases.findAll().stream()
+				.filter(TrackedCase::isIndexCase)
+				.filter(trackedCase -> OPEN.equals(trackedCase.getStatus()))
+				.filter(trackedCase -> {
+					var quarantineEnd = trackedCase.getQuarantine().getTo();
+					DateTime now = DateTime.now();
+					return now.isAfter(quarantineEnd.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC));
+				})
+				.collect(Collectors.toList());
+	}
+}

--- a/backend/src/main/java/quarano/actions/quarantine/QuarantineEndingActionItem.java
+++ b/backend/src/main/java/quarano/actions/quarantine/QuarantineEndingActionItem.java
@@ -1,0 +1,25 @@
+package quarano.actions.quarantine;
+
+import javax.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import quarano.actions.ActionItem;
+import quarano.actions.Description;
+import quarano.actions.DescriptionCode;
+import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
+
+/**
+ * @author Oliver Drotbohm
+ */
+@Entity
+@Getter
+@NoArgsConstructor(force = true, access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class QuarantineEndingActionItem extends ActionItem {
+
+	QuarantineEndingActionItem(TrackedPersonIdentifier person) {
+		super(person, ItemType.PROCESS_INCIDENT, Description.of(DescriptionCode.QUARANTINE_ENDING));
+	}
+}

--- a/backend/src/main/java/quarano/actions/quarantine/QuarantineEventListener.java
+++ b/backend/src/main/java/quarano/actions/quarantine/QuarantineEventListener.java
@@ -1,0 +1,44 @@
+package quarano.actions.quarantine;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import quarano.actions.ActionItemRepository;
+import quarano.department.TrackedCase;
+import quarano.department.TrackedCase.CaseConcluded;
+import quarano.department.TrackedCase.TrackedCaseIdentifier;
+import quarano.department.TrackedCaseRepository;
+import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class QuarantineEventListener {
+
+	private final ActionItemRepository items;
+	private final TrackedCaseRepository cases;
+
+	@EventListener
+	public void on(CaseConcluded event) {
+		TrackedCaseIdentifier quarantineCaseId = event.getCaseIdentifier();
+		deleteQuarantineActionItems(quarantineCaseId);
+	}
+
+	private void deleteQuarantineActionItems(TrackedCaseIdentifier quarantineCaseId) {
+		Optional<TrackedCase> quarantineCase = cases.findById(quarantineCaseId);
+		if (quarantineCase.isEmpty()) {
+			log.debug("Case {} concluded before QuarantineActionItem was created", quarantineCaseId);
+			return;
+		}
+		TrackedPersonIdentifier trackedPerson = getTrackedPersonIdentifier(quarantineCase.get());
+
+		items.findQuarantineEndingActionItemsFor(trackedPerson)
+				.forEach(items::delete);
+	}
+
+	private TrackedPersonIdentifier getTrackedPersonIdentifier(TrackedCase trackedCase) {
+		return trackedCase.getTrackedPerson().getId();
+	}
+}

--- a/backend/src/main/java/quarano/department/TrackedCase.java
+++ b/backend/src/main/java/quarano/department/TrackedCase.java
@@ -286,7 +286,7 @@ public class TrackedCase extends QuaranoAggregate<TrackedCase, TrackedCaseIdenti
 		}
 	}
 
-	public static enum Status {
+	public enum Status {
 
 		OPEN,
 

--- a/backend/src/main/java/quarano/tracking/schedules/DiaryEntryMissingChecker.java
+++ b/backend/src/main/java/quarano/tracking/schedules/DiaryEntryMissingChecker.java
@@ -1,4 +1,4 @@
-package quarano.tracking;
+package quarano.tracking.schedules;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +8,10 @@ import java.util.ArrayList;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import quarano.tracking.DiaryEntryMissing;
+import quarano.tracking.DiaryEntryRepository;
+import quarano.tracking.DiaryProperties;
+import quarano.tracking.Slot;
 
 /**
  * This class collects the persons with missing diary entries and publishes Events of them combining the slots with

--- a/backend/src/test/java/quarano/actions/quarantine/QuarantineEndCheckerTest.java
+++ b/backend/src/test/java/quarano/actions/quarantine/QuarantineEndCheckerTest.java
@@ -1,0 +1,164 @@
+package quarano.actions.quarantine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import org.joda.time.DateTimeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Streamable;
+import quarano.account.Department;
+import quarano.actions.ActionItemRepository;
+import quarano.actions.ActionItems;
+import quarano.actions.DescriptionCode;
+import quarano.department.CaseType;
+import quarano.department.TrackedCase;
+import quarano.department.TrackedCaseRepository;
+import quarano.tracking.Quarantine;
+import quarano.tracking.TrackedPerson;
+
+@ExtendWith(MockitoExtension.class)
+class QuarantineEndCheckerTest {
+
+	private static final Department DEPARTMENT = new Department("Department A");
+	private static final LocalDate DATE_2020_05_10 = LocalDate.of(2020, 5, 10);
+	private static final LocalDate DATE_2020_05_17 = LocalDate.of(2020, 5, 17);
+
+	private static final LocalDate DATE_2020_05_5 = LocalDate.of(2020, 5, 15);
+	private static final LocalDate DATE_2020_05_16 = LocalDate.of(2020, 5, 16);
+	private static final Quarantine QUARANTINE = Quarantine.of(DATE_2020_05_5, DATE_2020_05_16);
+
+	private static final TrackedCase TRACKED_CASE_A = new TrackedCase(
+			new TrackedPerson("Erika", "Musterfrau"),
+			CaseType.INDEX,
+			DEPARTMENT
+	).setQuarantine(QUARANTINE);
+
+	private static final TrackedCase TRACKED_CASE_B = new TrackedCase(
+			new TrackedPerson("Max", "Mustermann"),
+			CaseType.INDEX,
+			DEPARTMENT
+	).setQuarantine(QUARANTINE);
+
+	private static final TrackedCase TRACKED_CASE_C = new TrackedCase(
+			new TrackedPerson("Olaf", "Beispiel"),
+			CaseType.INDEX,
+			DEPARTMENT
+	).setQuarantine(QUARANTINE);
+
+	private static final TrackedCase TRACKED_CASE_D = new TrackedCase(
+			new TrackedPerson("Elfride", "Exampel"),
+			CaseType.CONTACT,
+			DEPARTMENT
+	);
+	private static final Streamable<TrackedCase> TRACKED_CASES =
+			Streamable.of(TRACKED_CASE_A, TRACKED_CASE_B, TRACKED_CASE_C, TRACKED_CASE_D);
+	private static final int ONCE = 1;
+	private static final int NEVER = 0;
+	private static final int THREE = 3;
+
+	@Mock private TrackedCaseRepository cases;
+	@Mock private ActionItemRepository items;
+
+	private QuarantineEndChecker quarantineEndChecker;
+
+	@BeforeEach
+	void setUp() {
+		quarantineEndChecker = new QuarantineEndChecker(cases, items);
+		when(cases.findAll()).thenReturn(TRACKED_CASES);
+	}
+
+	@Test
+	void expectToCreateThreeQuarantineEndingActionItem() {
+		prepareTestDateTime(DATE_2020_05_17);
+		prepareNonExistingActionItems();
+
+		quarantineEndChecker.checkEndingQuarantinesPeriodically();
+
+		ArgumentCaptor<QuarantineEndingActionItem> captor = verifyRepositorySaveInteraction(THREE);
+		verifyCreatedQuarantineEndingActionItems(captor);
+		verifyNonExistenceOfSuitableActionItems();
+	}
+
+	@Test
+	void expectToCreateNoQuarantineEndingActionItemsDueToDateFiltering() {
+		prepareTestDateTime(DATE_2020_05_10);
+
+		quarantineEndChecker.checkEndingQuarantinesPeriodically();
+
+		ArgumentCaptor<QuarantineEndingActionItem> captor = verifyRepositorySaveInteraction(NEVER);
+		verifyCreatedQuarantineEndingActionItems(captor);
+	}
+
+	@Test
+	void expectToCreateOneQuarantineEndingActionItemDueToExistingActionItems() {
+		prepareTestDateTime(DATE_2020_05_17);
+		prepareTwoExistingActionItems();
+
+		quarantineEndChecker.checkEndingQuarantinesPeriodically();
+
+		ArgumentCaptor<QuarantineEndingActionItem> captor = verifyRepositorySaveInteraction(ONCE);
+		verifyCreatedQuarantineEndingActionItems(captor);
+		verifyQuarantineEndingActionItemForTrackedCaseC(captor);
+	}
+
+	private void prepareTwoExistingActionItems() {
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_A.getTrackedPerson().getId()))
+				.thenReturn(ActionItems.of(new QuarantineEndingActionItem()));
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_B.getTrackedPerson().getId()))
+				.thenReturn(ActionItems.of(new QuarantineEndingActionItem()));
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_C.getTrackedPerson().getId()))
+				.thenReturn(ActionItems.empty());
+	}
+
+	private void verifyQuarantineEndingActionItemForTrackedCaseC(
+			ArgumentCaptor<QuarantineEndingActionItem> captor) {
+		assertThat(captor.getValue())
+				.isEqualTo(new QuarantineEndingActionItem(TRACKED_CASE_C.getTrackedPerson().getId()));
+	}
+
+	private void prepareTestDateTime(LocalDate date20200510) {
+		DateTimeUtils.setCurrentMillisFixed(date20200510.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC));
+	}
+
+	private void verifyCreatedQuarantineEndingActionItems(
+			ArgumentCaptor<QuarantineEndingActionItem> items) {
+		items.getAllValues()
+				.forEach(actionItem ->
+						assertThat(actionItem.getDescription().getCode())
+								.isEqualTo(DescriptionCode.QUARANTINE_ENDING));
+	}
+
+	private void verifyNonExistenceOfSuitableActionItems() {
+		verify(items).findQuarantineEndingActionItemsFor(TRACKED_CASE_A.getTrackedPerson().getId());
+		verify(items).findQuarantineEndingActionItemsFor(TRACKED_CASE_B.getTrackedPerson().getId());
+		verify(items).findQuarantineEndingActionItemsFor(TRACKED_CASE_C.getTrackedPerson().getId());
+	}
+
+	private void prepareNonExistingActionItems() {
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_A.getTrackedPerson().getId()))
+				.thenReturn(
+						ActionItems.empty());
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_B.getTrackedPerson().getId()))
+				.thenReturn(ActionItems.empty());
+		when(items.findQuarantineEndingActionItemsFor(TRACKED_CASE_C.getTrackedPerson().getId()))
+				.thenReturn(ActionItems.empty());
+	}
+
+	private ArgumentCaptor<QuarantineEndingActionItem> verifyRepositorySaveInteraction(int three) {
+		ArgumentCaptor<QuarantineEndingActionItem> quarantineEnding =
+				forClass(QuarantineEndingActionItem.class);
+		verify(items, times(three)).save(quarantineEnding.capture());
+		return quarantineEnding;
+	}
+}

--- a/backend/src/test/java/quarano/actions/quarantine/QuarantineEventListenerTest.java
+++ b/backend/src/test/java/quarano/actions/quarantine/QuarantineEventListenerTest.java
@@ -1,0 +1,78 @@
+package quarano.actions.quarantine;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import quarano.actions.ActionItemRepository;
+import quarano.actions.ActionItems;
+import quarano.department.TrackedCase;
+import quarano.department.TrackedCaseRepository;
+import quarano.tracking.TrackedPerson;
+
+@ExtendWith(MockitoExtension.class)
+class QuarantineEventListenerTest {
+
+	private static final TrackedCase.TrackedCaseIdentifier CASE_ID =
+			TrackedCase.TrackedCaseIdentifier.of(UUID.randomUUID());
+
+	private static final TrackedPerson.TrackedPersonIdentifier PERSON_ID =
+			TrackedPerson.TrackedPersonIdentifier.of(UUID.randomUUID());
+
+	private static final TrackedCase.CaseConcluded EVENT =
+			TrackedCase.CaseConcluded.of(CASE_ID);
+	private static final int NEVER = 0;
+
+	@Mock private ActionItemRepository items;
+
+	@Mock private TrackedCaseRepository cases;
+
+	@InjectMocks private QuarantineEventListener quarantineEventListener;
+
+	@Mock private TrackedCase trackedCase;
+
+	@Mock private TrackedPerson trackedPerson;
+	@Mock private QuarantineEndingActionItem actionItem;
+
+	@Test
+	void expectToDeleteExistingActionItems() {
+		when(cases.findById(CASE_ID)).thenReturn(Optional.of(trackedCase));
+		when(trackedCase.getTrackedPerson()).thenReturn(trackedPerson);
+		when(trackedPerson.getId()).thenReturn(PERSON_ID);
+		when(items.findQuarantineEndingActionItemsFor(PERSON_ID))
+				.thenReturn(ActionItems.of(actionItem));
+
+		quarantineEventListener.on(EVENT);
+
+		verify(items).delete(actionItem);
+	}
+
+	@Test
+	void expectToDeleteExecuteNoDeleteCall() {
+		when(cases.findById(CASE_ID)).thenReturn(Optional.of(trackedCase));
+		when(trackedCase.getTrackedPerson()).thenReturn(trackedPerson);
+		when(trackedPerson.getId()).thenReturn(PERSON_ID);
+		when(items.findQuarantineEndingActionItemsFor(PERSON_ID)).thenReturn(ActionItems.empty());
+
+		quarantineEventListener.on(EVENT);
+
+		verify(items, times(NEVER)).delete(actionItem);
+	}
+
+	@Test
+	void expectNoInteractionDueToNonExistingCase() {
+		when(cases.findById(CASE_ID)).thenReturn(Optional.empty());
+
+		quarantineEventListener.on(EVENT);
+
+		verifyNoInteractions(items, trackedCase);
+	}
+}

--- a/backend/src/test/java/quarano/department/MinimalQuestionnaire.java
+++ b/backend/src/test/java/quarano/department/MinimalQuestionnaire.java
@@ -8,7 +8,7 @@ class MinimalQuestionnaire extends Questionnaire {
 		super(symptomInformation, hasPreExistingConditionsDescription, belongToMedicalStaffDescription);
 	}
 
-	MinimalQuestionnaire() {
+	public MinimalQuestionnaire() {
 		super(SymptomInformation.withoutSymptoms(), null, null);
 	}
 }

--- a/backend/src/test/java/quarano/tracking/schedules/DiaryEntryMissingCheckerTest.java
+++ b/backend/src/test/java/quarano/tracking/schedules/DiaryEntryMissingCheckerTest.java
@@ -1,10 +1,9 @@
-package quarano.tracking;
+package quarano.tracking.schedules;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
-import quarano.QuaranoUnitTest;
-import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.List;
@@ -15,6 +14,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.util.Streamable;
+import quarano.QuaranoUnitTest;
+import quarano.tracking.DiaryEntryMissing;
+import quarano.tracking.DiaryEntryRepository;
+import quarano.tracking.DiaryProperties;
+import quarano.tracking.Slot;
+import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
 @QuaranoUnitTest
 class DiaryEntryMissingCheckerTest {
@@ -35,14 +40,16 @@ class DiaryEntryMissingCheckerTest {
 
 		when(properties.getToleratedSlotCount()).thenReturn(4);
 		ArgumentCaptor<List<Slot>> slotsCaptor = ArgumentCaptor.forClass(List.class);
-		when(diaries.findMissingDiaryEntryPersons(slotsCaptor.capture())).thenReturn(Streamable.of(expectedPersons));
+		when(diaries.findMissingDiaryEntryPersons(slotsCaptor.capture()))
+				.thenReturn(Streamable.of(expectedPersons));
 
 		checker.collectAndPublishMissingEntryPersons();
 
 		List<Slot> slots = slotsCaptor.getValue();
 		assertThat(slots).hasSize(5);
 
-		ArgumentCaptor<DiaryEntryMissing> missingCaptor = ArgumentCaptor.forClass(DiaryEntryMissing.class);
+		ArgumentCaptor<DiaryEntryMissing> missingCaptor =
+				ArgumentCaptor.forClass(DiaryEntryMissing.class);
 		verify(publisher, times(expectedPersons.size())).publishEvent(missingCaptor.capture());
 
 		List<DiaryEntryMissing> diaryEntryMissings = missingCaptor.getAllValues();
@@ -56,7 +63,8 @@ class DiaryEntryMissingCheckerTest {
 	}
 
 	private Collection<TrackedPersonIdentifier> personIdentifiers() {
-		return List.of(TrackedPersonIdentifier.of(UUID.randomUUID()), TrackedPersonIdentifier.of(UUID.randomUUID()),
+		return List.of(TrackedPersonIdentifier.of(UUID.randomUUID()),
+				TrackedPersonIdentifier.of(UUID.randomUUID()),
 				TrackedPersonIdentifier.of(UUID.randomUUID()));
 	}
 


### PR DESCRIPTION
• QuarantineEndChecker for scheduling Quarantine checks of TrackedCases
• QuarantineEndingActionItem to indicate ending Quarantine
• QuarantineEventListener to remove existing QuarantineEndingActionItem on CaseConcluded

Additionally fix some IDE warnings

Additional changes:
- Add @EnableScheduling annotation to enable two scheduled components
- Move scheduled components into /schedulers package, to classify component type in domain