### PR TITLE
Fix positions of error messages

### DIFF
--- a/frontend/apps/quarano-frontend/src/app/modules/basic-data/basic-data.component.html
+++ b/frontend/apps/quarano-frontend/src/app/modules/basic-data/basic-data.component.html
@@ -9,7 +9,7 @@
     <ng-template matStepLabel>Persönliche Daten</ng-template>
     <p>Pflichtfelder sind mit * markiert</p>
     <form [formGroup]="firstFormGroup">
-      <qro-personal-data-form [formGroup]="firstFormGroup"></qro-personal-data-form>
+      <qro-personal-data-form [formGroup]="firstFormGroup" class="personal-data-form"></qro-personal-data-form>
       <div class="mt-3">
         <button mat-raised-button color="primary" [disabled]="firstStep.hasError"
                 (click)="checkAndSendFirstForm()">

--- a/frontend/apps/quarano-frontend/src/app/modules/profile/profile.component.html
+++ b/frontend/apps/quarano-frontend/src/app/modules/profile/profile.component.html
@@ -6,7 +6,7 @@
       <mat-card-subtitle>Pflichteingaben sind mit * markiert</mat-card-subtitle>
     </mat-card-header>
     <mat-card-content>
-      <qro-personal-data-form [formGroup]="formGroup"></qro-personal-data-form>
+      <qro-personal-data-form [formGroup]="formGroup" class="personal-data-form"></qro-personal-data-form>
     </mat-card-content>
     <mat-card-actions>
       <button

--- a/frontend/apps/quarano-frontend/src/styles/_forms.scss
+++ b/frontend/apps/quarano-frontend/src/styles/_forms.scss
@@ -2,11 +2,14 @@
   width: 100%;
 }
 
-.form__card--small {
+.form__card--small,
+.personal-data-form {
   .mat-form-field-subscript-wrapper {
     position: inherit !important;
   }
+}
 
+.form__card--small {
   @extend .mx-auto;
   max-width: 700px;
 


### PR DESCRIPTION
This change fixes the position of the error messages in the personal
data form. A fix, that was already applied to fix the positioning of
error messages in forms, was reused.
Now, the error messages are not positioned absolutely in the document
anymore.