### PR TITLE
Feature/core 188 separate contact infos

### DIFF
--- a/backend/src/main/java/quarano/account/AccountBootstrap.java
+++ b/backend/src/main/java/quarano/account/AccountBootstrap.java
@@ -35,18 +35,18 @@ public class AccountBootstrap implements ApplicationRunner {
 	public void run(ApplicationArguments args) throws Exception {
 
 		Department defaultDepartment = configuration.getDefaultDepartment();
+
 		if (departments.count() > 0) {
 
 			log.info("Found departments in database. Updating their contact informations");
 
-			String departmentName = defaultDepartment.getName();
-			departments.findByName(departmentName)
+			departments.findByName(defaultDepartment.getName()) //
 					.map(department -> {
 						// workaround for hibernate as orphanremoval is not working here
 						departments.deleteDepartmentContacts(department.getContacts());
 						return department;
-					})
-					.map(department -> department.addDepartmentContacts(defaultDepartment.getContacts()))
+					}) //
+					.map(department -> department.add(defaultDepartment.getContacts())) //
 					.ifPresent(departments::save);
 
 			return;
@@ -57,7 +57,6 @@ public class AccountBootstrap implements ApplicationRunner {
 		var department = departments.save(defaultDepartment);
 		var defaults = configuration.getDefaultAccount();
 
-
 		// create initial roles
 		for (RoleType type : RoleType.values()) {
 
@@ -67,11 +66,9 @@ public class AccountBootstrap implements ApplicationRunner {
 				continue;
 			}
 			log.info("Creating initial role " + type.getCode());
-			
+
 			roleRepository.save(new Role(type));
 		}
-
-		
 
 		log.info("Creating default account (root, root).");
 
@@ -80,6 +77,6 @@ public class AccountBootstrap implements ApplicationRunner {
 				defaults.getLastname(), //
 				EmailAddress.of(defaults.getEmailAddress()), //
 				department.getId(), RoleType.ROLE_HD_ADMIN);
-		
+
 	}
 }

--- a/backend/src/main/java/quarano/account/Department.java
+++ b/backend/src/main/java/quarano/account/Department.java
@@ -1,5 +1,7 @@
 package quarano.account;
 
+import static quarano.account.DepartmentContact.*;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -7,16 +9,21 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import quarano.account.Department.DepartmentIdentifier;
-import quarano.core.EmailAddress;
-import quarano.core.PhoneNumber;
 import quarano.core.QuaranoAggregate;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.jddd.core.types.Identifier;
@@ -32,8 +39,9 @@ import org.jddd.core.types.Identifier;
 public class Department extends QuaranoAggregate<Department, DepartmentIdentifier> {
 
 	private @Getter @Column(unique = true) String name;
-	private @Getter @Setter EmailAddress emailAddress;
-	private @Getter @Setter PhoneNumber phoneNumber;
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+	@JoinColumn(name = "department_id")
+	private @Getter @Setter	Set<DepartmentContact> contacts = new HashSet<>();
 
 	public Department(String name) {
 		this(name, UUID.randomUUID());
@@ -50,6 +58,17 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 		this.name = name;
 	}
 
+	Department addDepartmentContacts(Collection<DepartmentContact> departmentContacts) {
+		departmentContacts.forEach(departmentContact -> this.getContacts().add(departmentContact));
+		return this;
+	}
+
+	public Optional<DepartmentContact> getContact(ContactType contactType) {
+		return getContacts().stream()
+				.filter(contact -> contact.getType().equals(contactType))
+				.findFirst();
+	}
+
 	@Embeddable
 	@EqualsAndHashCode
 	@RequiredArgsConstructor(staticName = "of")
@@ -64,4 +83,5 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 			return departmentId.toString();
 		}
 	}
+
 }

--- a/backend/src/main/java/quarano/account/Department.java
+++ b/backend/src/main/java/quarano/account/Department.java
@@ -1,7 +1,5 @@
 package quarano.account;
 
-import static quarano.account.DepartmentContact.*;
-
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -9,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import quarano.account.Department.DepartmentIdentifier;
+import quarano.account.DepartmentContact.ContactType;
 import quarano.core.QuaranoAggregate;
 
 import java.io.Serializable;
@@ -39,9 +38,10 @@ import org.jddd.core.types.Identifier;
 public class Department extends QuaranoAggregate<Department, DepartmentIdentifier> {
 
 	private @Getter @Column(unique = true) String name;
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JoinColumn(name = "department_id")
-	private @Getter @Setter	Set<DepartmentContact> contacts = new HashSet<>();
+
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true) //
+	@JoinColumn(name = "department_id") //
+	private @Getter @Setter Set<DepartmentContact> contacts = new HashSet<>();
 
 	public Department(String name) {
 		this(name, UUID.randomUUID());
@@ -58,15 +58,14 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 		this.name = name;
 	}
 
-	Department addDepartmentContacts(Collection<DepartmentContact> departmentContacts) {
-		departmentContacts.forEach(departmentContact -> this.getContacts().add(departmentContact));
+	Department add(Collection<DepartmentContact> departmentContacts) {
+
+		this.contacts.addAll(departmentContacts);
 		return this;
 	}
 
 	public Optional<DepartmentContact> getContact(ContactType contactType) {
-		return getContacts().stream()
-				.filter(contact -> contact.getType().equals(contactType))
-				.findFirst();
+		return getContacts().stream().filter(contact -> contact.getType().equals(contactType)).findFirst();
 	}
 
 	@Embeddable
@@ -74,6 +73,7 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 	@RequiredArgsConstructor(staticName = "of")
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class DepartmentIdentifier implements Identifier, Serializable {
+
 		private static final long serialVersionUID = 7871473225101042167L;
 
 		final UUID departmentId;
@@ -83,5 +83,4 @@ public class Department extends QuaranoAggregate<Department, DepartmentIdentifie
 			return departmentId.toString();
 		}
 	}
-
 }

--- a/backend/src/main/java/quarano/account/DepartmentContact.java
+++ b/backend/src/main/java/quarano/account/DepartmentContact.java
@@ -1,0 +1,58 @@
+package quarano.account;
+
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import quarano.core.EmailAddress;
+import quarano.core.PhoneNumber;
+import quarano.core.QuaranoEntity;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+
+import org.jddd.core.types.Identifier;
+
+@Entity
+@Table(name = "departments_contacts")
+@EqualsAndHashCode(callSuper = true, of = {})
+public class DepartmentContact extends QuaranoEntity<Department, DepartmentContact.DepartmentContactIdentifier> {
+	private @Enumerated(EnumType.STRING) @Getter @Setter ContactType type;
+	private @Getter @Setter EmailAddress emailAddress;
+	private @Getter @Setter PhoneNumber phoneNumber;
+
+	private DepartmentContact() {
+		this.id = DepartmentContactIdentifier.of(UUID.randomUUID());
+	}
+
+	public enum ContactType {
+		INDEX, CONTACT
+	}
+
+	public static DepartmentContact of() {
+		return new DepartmentContact();
+	}
+
+	@Embeddable
+	@EqualsAndHashCode
+	@RequiredArgsConstructor(staticName = "of")
+	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+	public static class DepartmentContactIdentifier implements Identifier, Serializable {
+		private static final long serialVersionUID = 7871473225101042167L;
+
+		final UUID departmentContactId;
+
+		@Override
+		public String toString() {
+			return departmentContactId.toString();
+		}
+	}
+}

--- a/backend/src/main/java/quarano/account/DepartmentContact.java
+++ b/backend/src/main/java/quarano/account/DepartmentContact.java
@@ -24,10 +24,13 @@ import org.jddd.core.types.Identifier;
 @Entity
 @Table(name = "departments_contacts")
 @EqualsAndHashCode(callSuper = true, of = {})
+@Getter
+@Setter
 public class DepartmentContact extends QuaranoEntity<Department, DepartmentContact.DepartmentContactIdentifier> {
-	private @Enumerated(EnumType.STRING) @Getter @Setter ContactType type;
-	private @Getter @Setter EmailAddress emailAddress;
-	private @Getter @Setter PhoneNumber phoneNumber;
+
+	private @Enumerated(EnumType.STRING) ContactType type;
+	private EmailAddress emailAddress;
+	private PhoneNumber phoneNumber;
 
 	private DepartmentContact() {
 		this.id = DepartmentContactIdentifier.of(UUID.randomUUID());
@@ -46,6 +49,7 @@ public class DepartmentContact extends QuaranoEntity<Department, DepartmentConta
 	@RequiredArgsConstructor(staticName = "of")
 	@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 	public static class DepartmentContactIdentifier implements Identifier, Serializable {
+
 		private static final long serialVersionUID = 7871473225101042167L;
 
 		final UUID departmentContactId;

--- a/backend/src/main/java/quarano/account/DepartmentDataInitializer.java
+++ b/backend/src/main/java/quarano/account/DepartmentDataInitializer.java
@@ -23,12 +23,11 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class DepartmentDataInitializer implements DataInitializer {
 
-	private final @NonNull DepartmentRepository departments;
-
 	public final static DepartmentIdentifier DEPARTMENT_ID_DEP1 = DepartmentIdentifier
 			.of(UUID.fromString("aba0ec65-6c1d-4b7b-91b4-c31ef16ad0a2"));
 	public final static DepartmentIdentifier DEPARTMENT_ID_DEP2 = DepartmentIdentifier
 			.of(UUID.fromString("ca3f3e9a-414a-4117-a623-59b109b269f1"));
+	private final @NonNull DepartmentRepository departments;
 
 	/*
 	 * (non-Javadoc)
@@ -46,11 +45,28 @@ public class DepartmentDataInitializer implements DataInitializer {
 
 		departments.saveAll(List.of( //
 				new Department("GA Mannheim", DEPARTMENT_ID_DEP1) //
-						.setEmailAddress(EmailAddress.of("email@gamannheim.de")) //
-						.setPhoneNumber(PhoneNumber.of("0123456789")), //
+						.addDepartmentContacts(List.of( //
+								DepartmentContact.of() //
+										.setType(DepartmentContact.ContactType.INDEX) //
+										.setEmailAddress(EmailAddress.of("index-email@gamannheim.de")) //
+										.setPhoneNumber(PhoneNumber.of("0123456789")), //
+								DepartmentContact.of() //
+										.setType(DepartmentContact.ContactType.CONTACT) //
+										.setEmailAddress(EmailAddress.of("contact-email@gamannheim.de")) //
+										.setPhoneNumber(PhoneNumber.of("00123456789")) //
+						) //
+					), //
 				new Department("GA Darmstadt", DEPARTMENT_ID_DEP2) //
-						.setEmailAddress(EmailAddress.of("email@gadarmstadt.de")) //
-						.setPhoneNumber(PhoneNumber.of("0123456789")) //
+						.addDepartmentContacts(List.of( //
+								DepartmentContact.of() //
+										.setType(DepartmentContact.ContactType.INDEX) //
+								.setEmailAddress(EmailAddress.of("index-email@gadarmstadt.de")) //
+								.setPhoneNumber(PhoneNumber.of("0123456789")), //
+								DepartmentContact.of() //
+										.setType(DepartmentContact.ContactType.CONTACT)
+										.setEmailAddress(EmailAddress.of("contact-email@gadarmstadt.de")) //
+										.setPhoneNumber(PhoneNumber.of("00123456789")) //
+						)) //
 		));
 	}
 }

--- a/backend/src/main/java/quarano/account/DepartmentDataInitializer.java
+++ b/backend/src/main/java/quarano/account/DepartmentDataInitializer.java
@@ -45,7 +45,7 @@ public class DepartmentDataInitializer implements DataInitializer {
 
 		departments.saveAll(List.of( //
 				new Department("GA Mannheim", DEPARTMENT_ID_DEP1) //
-						.addDepartmentContacts(List.of( //
+						.add(List.of( //
 								DepartmentContact.of() //
 										.setType(DepartmentContact.ContactType.INDEX) //
 										.setEmailAddress(EmailAddress.of("index-email@gamannheim.de")) //
@@ -57,7 +57,7 @@ public class DepartmentDataInitializer implements DataInitializer {
 						) //
 					), //
 				new Department("GA Darmstadt", DEPARTMENT_ID_DEP2) //
-						.addDepartmentContacts(List.of( //
+						.add(List.of( //
 								DepartmentContact.of() //
 										.setType(DepartmentContact.ContactType.INDEX) //
 								.setEmailAddress(EmailAddress.of("index-email@gadarmstadt.de")) //

--- a/backend/src/main/java/quarano/account/DepartmentProperties.java
+++ b/backend/src/main/java/quarano/account/DepartmentProperties.java
@@ -2,6 +2,7 @@ package quarano.account;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import quarano.account.DepartmentContact.ContactType;
 import quarano.core.EmailAddress;
 import quarano.core.PhoneNumber;
 
@@ -24,18 +25,17 @@ public class DepartmentProperties {
 
 	Department getDefaultDepartment() {
 		return new Department(defaultDepartment.name) //
-				.addDepartmentContacts(
-						defaultDepartment.contacts.stream()
-							.map(contact -> DepartmentContact.of()
-									.setType(DepartmentContact.ContactType.valueOf(contact.type)) //
-									.setEmailAddress(EmailAddress.of(contact.emailAddress)) //
-									.setPhoneNumber(PhoneNumber.of(contact.phoneNumber))
-							).collect(Collectors.toList())
-				);
+				.add(defaultDepartment.contacts.stream() //
+						.map(contact -> DepartmentContact.of() //
+								.setType(ContactType.valueOf(contact.type)) //
+								.setEmailAddress(EmailAddress.of(contact.emailAddress)) //
+								.setPhoneNumber(PhoneNumber.of(contact.phoneNumber))) //
+						.collect(Collectors.toList()));
 	}
 
 	@RequiredArgsConstructor
 	static class DefaultDepartment {
+
 		private final String name;
 		private final List<DefaultDepartmentContact> contacts;
 

--- a/backend/src/main/java/quarano/account/DepartmentProperties.java
+++ b/backend/src/main/java/quarano/account/DepartmentProperties.java
@@ -5,6 +5,9 @@ import lombok.RequiredArgsConstructor;
 import quarano.core.EmailAddress;
 import quarano.core.PhoneNumber;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
@@ -19,21 +22,32 @@ public class DepartmentProperties {
 	private final DefaultDepartment defaultDepartment;
 	private final @Getter DefaultAdminAccount defaultAccount;
 
+	Department getDefaultDepartment() {
+		return new Department(defaultDepartment.name) //
+				.addDepartmentContacts(
+						defaultDepartment.contacts.stream()
+							.map(contact -> DepartmentContact.of()
+									.setType(DepartmentContact.ContactType.valueOf(contact.type)) //
+									.setEmailAddress(EmailAddress.of(contact.emailAddress)) //
+									.setPhoneNumber(PhoneNumber.of(contact.phoneNumber))
+							).collect(Collectors.toList())
+				);
+	}
+
 	@RequiredArgsConstructor
 	static class DefaultDepartment {
-		private final String name, emailAddress, phoneNumber;
+		private final String name;
+		private final List<DefaultDepartmentContact> contacts;
+
+		@RequiredArgsConstructor
+		static class DefaultDepartmentContact {
+			private final String type, emailAddress, phoneNumber;
+		}
 	}
 
 	@Getter
 	@RequiredArgsConstructor
 	static class DefaultAdminAccount {
 		private final String firstname, lastname, emailAddress;
-	}
-
-	Department getDefaultDepartment() {
-
-		return new Department(defaultDepartment.name) //
-				.setEmailAddress(EmailAddress.of(defaultDepartment.emailAddress)) //
-				.setPhoneNumber(PhoneNumber.of(defaultDepartment.phoneNumber));
 	}
 }

--- a/backend/src/main/java/quarano/account/DepartmentRepository.java
+++ b/backend/src/main/java/quarano/account/DepartmentRepository.java
@@ -3,7 +3,12 @@ package quarano.account;
 import quarano.account.Department.DepartmentIdentifier;
 import quarano.core.QuaranoRepository;
 
+import java.util.Collection;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * @author Oliver Drotbohm
@@ -11,4 +16,8 @@ import java.util.Optional;
 public interface DepartmentRepository extends QuaranoRepository<Department, DepartmentIdentifier> {
 
 	Optional<Department> findByName(String name);
+
+	@Modifying
+	@Query("delete from DepartmentContact departmentContact where departmentContact in :departmentContacts")
+	void deleteDepartmentContacts(@Param("departmentContacts") Collection<DepartmentContact> departmentContacts);
 }

--- a/backend/src/main/java/quarano/user/web/DepartmentDto.java
+++ b/backend/src/main/java/quarano/user/web/DepartmentDto.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import quarano.account.Department;
+import quarano.account.DepartmentContact;
 
 @Data
 @Builder
@@ -14,4 +16,10 @@ class DepartmentDto {
 	private String name;
 	private String email;
 	private String phone;
+
+	public static DepartmentDto of(Department department, DepartmentContact contact) {
+
+		return new DepartmentDto(department.getName(), contact.getEmailAddress().toString(),
+				contact.getPhoneNumber().toString());
+	}
 }

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import quarano.account.Account;
 import quarano.account.AccountService;
-import quarano.account.DepartmentContact;
+import quarano.account.DepartmentContact.ContactType;
 import quarano.account.DepartmentRepository;
 import quarano.account.Password.EncryptedPassword;
 import quarano.account.Password.UnencryptedPassword;
@@ -60,14 +60,13 @@ public class UserController {
 				.ifPresent(userDto::setEnrollment);
 
 		trackedCase.map(TrackedCase::getType) //
-				.flatMap(type -> { //
-					var contactType = CaseType.INDEX == type ? DepartmentContact.ContactType.INDEX
-							: DepartmentContact.ContactType.CONTACT; //
+				.flatMap(type -> {
+
+					var contactType = CaseType.INDEX == type ? ContactType.INDEX : ContactType.CONTACT;
+
 					return departments.findById(account.getDepartmentId()) //
-							.flatMap(department -> //
-					department.getContact(contactType) //
-							.map(contact -> new DepartmentDto(department.getName(), contact.getEmailAddress().toString(),
-									contact.getPhoneNumber().toString())));
+							.flatMap(department -> department.getContact(contactType) //
+									.map(contact -> DepartmentDto.of(department, contact)));
 				}) //
 				.ifPresent(userDto::setHealthDepartment);
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -21,9 +21,13 @@ quarano.account-activation.expiration=24h
 quarano.anomalies.temperature-threshold=39.5f
 quarano.diary.tolerated-slot-count=1
 
-quarano.department.default-department.name=Gesundheitsamt
-quarano.department.default-department.email-address=email@gesundheitsamt.de
-quarano.department.default-department.phone-number=01234567890
+quarano.department.default-department.name=GA Mannheim
+quarano.department.default-department.contacts[0].TYPE=INDEX
+quarano.department.default-department.contacts[0].email-address=index-email@gesundheitsamt.de
+quarano.department.default-department.contacts[0].phone-number=0123456789
+quarano.department.default-department.contacts[1].TYPE=CONTACT
+quarano.department.default-department.contacts[1].email-address=contact-email@gesundheitsamt.de
+quarano.department.default-department.contacts[1].phone-number=0012345678902
 
 quarano.department.default-account.firstname=Max
 quarano.department.default-account.lastname=Mustermann

--- a/backend/src/main/resources/db/migration/V0004__departments_separate-phone-numbers.sql
+++ b/backend/src/main/resources/db/migration/V0004__departments_separate-phone-numbers.sql
@@ -1,0 +1,21 @@
+CREATE TABLE departments_contacts (
+     department_contact_id uuid NOT NULL,
+     created timestamp NULL,
+     created_by uuid NULL,
+     last_modified timestamp NULL,
+     last_modified_by uuid NULL,
+     type varchar(255) NOT NULL,
+     email varchar(255) NOT NULL,
+     phone_number varchar(255) NOT NULL,
+     department_id uuid NULL,
+     CONSTRAINT department_contacts_pkey PRIMARY KEY (department_contact_id),
+     CONSTRAINT uk_dep_cont UNIQUE (department_id, type),
+     CONSTRAINT contact_department_fk FOREIGN KEY (department_id) REFERENCES departments(department_id)
+);
+
+-- we use the department_id also as this id, because there is no single uuid-generate method on h2 and postgres
+INSERT INTO departments_contacts (department_contact_id, type, email, phone_number, department_id)
+    SELECT department_id, 'INDEX', email, phone_number, department_id FROM departments;
+
+ALTER TABLE departments DROP COLUMN email;
+ALTER TABLE departments DROP COLUMN phone_number;

--- a/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
@@ -52,7 +52,7 @@ class UserControllerWebIntegrationTests {
 		assertThat(document.read("$.firstName", String.class)).isEqualTo("Markus");
 		assertThat(document.read("$.lastName", String.class)).isEqualTo("Hanser");
 		assertThat(document.read("$.healthDepartment.name", String.class)).isEqualTo("GA Mannheim");
-		assertThat(document.read("$.healthDepartment.email", String.class)).isEqualTo("email@gamannheim.de");
+		assertThat(document.read("$.healthDepartment.email", String.class)).isEqualTo("index-email@gesundheitsamt.de");
 		assertThat(document.read("$.healthDepartment.phone", String.class)).isEqualTo("0123456789");
 	}
 

--- a/frontend/apps/quarano-frontend/src/app/modules/welcome/landing/landing.component.html
+++ b/frontend/apps/quarano-frontend/src/app/modules/welcome/landing/landing.component.html
@@ -60,7 +60,8 @@
             <p>Fühlen Sie sich aktuell schwer krank oder werden die Symptome schlimmer, rufen Sie bitte Ihren Hausarzt
                 an oder den Ärztlicher Bereitschaftsdienst (Tel: 116 117).</p>
             <p>Bei sonstigen Rückfragen melden Sie sich bitte auf unserem</p>
-            <p>Hotline-Telefon (0621-293-2253 von 07:30 Uhr bis 19 Uhr).</p>
+            <p *ngIf="showIndexNumber()">Hotline-Telefon (0621-293-2253 von 07:30 Uhr bis 19 Uhr).</p>
+            <p *ngIf="showContactNumber()">Hotline-Telefon (0621-293-XXXX von 07:30 Uhr bis 19 Uhr).</p>
             <p>Ihr Gesundheitsamt Mannheim</p>
             <p class="footnote"><em>*nähere Informationen hierzu finden Sie auf den Seiten des Robert Koch
                     Instituts<br /><a

--- a/frontend/apps/quarano-frontend/src/app/modules/welcome/landing/landing.component.ts
+++ b/frontend/apps/quarano-frontend/src/app/modules/welcome/landing/landing.component.ts
@@ -1,6 +1,6 @@
-import { ClientType } from '@quarano-frontend/health-department/domain';
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import {ClientType} from '@quarano-frontend/health-department/domain';
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
 
 @Component({
   selector: 'qro-landing',
@@ -17,5 +17,12 @@ export class LandingComponent implements OnInit {
   ngOnInit(): void {
     this.userType = this.route.snapshot.paramMap.get('usertype') as ClientType || this.userType;
     this.clientcode = this.route.snapshot.paramMap.get('clientcode');
+  }
+
+  showIndexNumber() {
+    return this.userType === ClientType.Index;
+  }
+  showContactNumber() {
+    return this.userType === ClientType.Contact;
   }
 }


### PR DESCRIPTION
Add department contact (hotline) informations to database. 
We need separate types of that information, e.g. INDEX and CONTACT, that relates in some way to the CaseType.
On App Start, the default department is updated with the property informations. Until we can use a something like a Admin UI, we have to update those fields that way.