### PR TITLE
CORE-189 Zweiter Nachtrag von Kontakten über Tagebuch funktioniert nicht

### DIFF
--- a/backend/src/main/java/quarano/department/TrackedCaseRepository.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseRepository.java
@@ -3,6 +3,7 @@ package quarano.department;
 import quarano.account.Department.DepartmentIdentifier;
 import quarano.core.QuaranoRepository;
 import quarano.department.TrackedCase.TrackedCaseIdentifier;
+import quarano.tracking.ContactPerson;
 import quarano.tracking.TrackedPerson;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
@@ -25,4 +26,6 @@ public interface TrackedCaseRepository extends QuaranoRepository<TrackedCase, Tr
 
 	@Query("select c from TrackedCase c where c.trackedPerson.id = :identifier")
 	Optional<TrackedCase> findByTrackedPerson(TrackedPersonIdentifier identifier);
+	
+	Streamable<TrackedCase> findByOriginContacts(ContactPerson person);
 }

--- a/backend/src/main/java/quarano/tracking/DiaryEntry.java
+++ b/backend/src/main/java/quarano/tracking/DiaryEntry.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import quarano.core.QuaranoAggregate;
+import quarano.department.TrackedCase;
+import quarano.department.TrackedCase.CaseUpdated;
 import quarano.reference.Symptom;
 import quarano.tracking.DiaryEntry.DiaryEntryIdentifier;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
@@ -133,6 +135,13 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 		return BY_DATE.compare(this, that);
 	}
 
+	public DiaryEntry markEdited() {
+
+		registerEvent(DiaryEntryUpdated.of(this));
+
+		return this;
+	}
+
 	@Embeddable
 	@EqualsAndHashCode
 	@RequiredArgsConstructor(staticName = "of")
@@ -155,6 +164,11 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 
 	@Value(staticConstructor = "of")
 	public static class DiaryEntryAdded implements DomainEvent {
+		DiaryEntry entry;
+	}
+	
+	@Value(staticConstructor = "of")
+	public static class DiaryEntryUpdated implements DomainEvent {
 		DiaryEntry entry;
 	}
 }

--- a/backend/src/main/java/quarano/tracking/web/DiaryRepresentations.java
+++ b/backend/src/main/java/quarano/tracking/web/DiaryRepresentations.java
@@ -75,7 +75,7 @@ class DiaryRepresentations {
 	}
 
 	Either<DiaryEntry, Errors> from(DiaryEntryInput input, DiaryEntry existing, Errors errors) {
-		return mapper.map(input, existing, errors);
+		return mapper.map(input, existing, errors).peekLeft(DiaryEntry::markEdited);
 	}
 
 	@Data


### PR DESCRIPTION
The TrackedPerson was created after a DiaryEntryAdded event but there
was no update event. Now an DiaryEntryUpdate event is registered for
changes to the entry and this event is handled.

Adds a test of DiaryEntry event handling, where first DiaryEntryAdded
and then DiaryEntryUpdated occurs.

Adds a check if there already a TrackedCase with the new contact person
in originContacts. If this check is missing, an existing contact of the
processed DiaryEntry is created again.