### PR TITLE
Bugfix/core 222 fieber von kontakt fall nicht in aktionsübersicht

### DIFF
--- a/backend/src/main/java/quarano/actions/ActionItemRepository.java
+++ b/backend/src/main/java/quarano/actions/ActionItemRepository.java
@@ -39,6 +39,9 @@ public interface ActionItemRepository extends QuaranoRepository<ActionItem, Acti
 
 	@Query("select i from ActionItem i where i.personIdentifier = :identifier and i.description.code = :code")
 	ActionItems findByDescriptionCode(TrackedPersonIdentifier identifier, DescriptionCode code);
+	
+	@Query("select i from ActionItem i where i.personIdentifier = :identifier and i.description.code = :code and i.resolved = false")
+	ActionItems findUnresolvedByDescriptionCode(TrackedPersonIdentifier identifier, DescriptionCode code);
 
 	@Query("select i from DiaryEntryMissingActionItem i" //
 			+ " where i.slot = :slot" //

--- a/backend/src/main/java/quarano/actions/DiaryEventListener.java
+++ b/backend/src/main/java/quarano/actions/DiaryEventListener.java
@@ -62,7 +62,7 @@ class DiaryEventListener {
 			return;
 		}
 
-		items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE) //
+		items.findUnresolvedByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE) //
 				.resolveAutomatically(items::save);
 
 		// Body temperature exceeds reference
@@ -93,7 +93,7 @@ class DiaryEventListener {
 		var slot = entry.getSlot();
 		var person = entry.getTrackedPersonId();
 
-		var actionItems = items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM);
+		var actionItems = items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM);
 		var diaryEntryActionItems = actionItems.filter(DiaryEntryActionItem.class::isInstance)//
 				.map(DiaryEntryActionItem.class::cast);
 

--- a/backend/src/main/java/quarano/actions/DiaryEventListener.java
+++ b/backend/src/main/java/quarano/actions/DiaryEventListener.java
@@ -5,7 +5,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import quarano.actions.ActionItem.ItemType;
 import quarano.diary.DiaryEntryMissing;
+import quarano.diary.DiaryManagement;
+import quarano.diary.Slot;
+import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
+import quarano.diary.DiaryEntry;
 import quarano.diary.DiaryEntry.DiaryEntryAdded;
+import quarano.diary.DiaryEntry.DiaryEntryUpdated;
+
+import java.util.Comparator;
 
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -17,6 +24,7 @@ class DiaryEventListener {
 
 	private final @NonNull AnomaliesProperties config;
 	private final @NonNull ActionItemRepository items;
+	private final @NonNull DiaryManagement diaryManagement;
 
 	@EventListener
 	void onDiaryEntryAddedToResolveMissingItems(DiaryEntryAdded event) {
@@ -32,38 +40,98 @@ class DiaryEventListener {
 
 	@EventListener
 	void onDiaryEntryAddedForBodyTemperature(DiaryEntryAdded event) {
+		handleDiaryEntryForBodyTemprature(event.getEntry());
+	}
 
-		var entry = event.getEntry();
+	@EventListener
+	void onDiaryEntryUpdatedForBodyTemperature(DiaryEntryUpdated event) {
+		handleDiaryEntryForBodyTemprature(event.getEntry());
+	}
+
+	/**
+	 * Only does something if the entry with the most current slot is edited. First resolves all existing action items for
+	 * temperature. If handles an added or updated diary entry with to high temperature a new action item is added. There
+	 * is no update of existing items.
+	 * 
+	 * @param entry
+	 */
+	private void handleDiaryEntryForBodyTemprature(DiaryEntry entry) {
 		var person = entry.getTrackedPersonId();
+
+		if (!determineWhetherEntryMostRecent(person, entry.getSlot())) {
+			return;
+		}
+
+		items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE) //
+				.resolveAutomatically(items::save);
 
 		// Body temperature exceeds reference
 		if (entry.getBodyTemperature().exceeds(config.getTemperatureThreshold())) {
-
 			Description description = Description.of(DescriptionCode.INCREASED_TEMPERATURE, //
 					entry.getBodyTemperature(), //
 					config.getTemperatureThreshold());
 
 			items.save(new DiaryEntryActionItem(person, entry, ItemType.MEDICAL_INCIDENT, description));
-		} else {
-			items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE) //
-					.resolveAutomatically(items::save);
 		}
+	}
+
+	private boolean determineWhetherEntryMostRecent(TrackedPersonIdentifier personId, Slot slot) {
+		return diaryManagement.findDiaryFor(personId).filter(it -> it.getSlot().compareTo(slot) > 0).isEmpty();
 	}
 
 	@EventListener
 	void onDiaryEntryAddedForCharacteristicSymptoms(DiaryEntryAdded event) {
+		handleDiaryEntryForCharacteristicSymptoms(event.getEntry());
+	}
 
-		var entry = event.getEntry();
+	@EventListener
+	void onDiaryEntryUpdatedForCharacteristicSymptoms(DiaryEntryUpdated event) {
+		handleDiaryEntryForCharacteristicSymptoms(event.getEntry());
+	}
+
+	private void handleDiaryEntryForCharacteristicSymptoms(DiaryEntry entry) {
+		var slot = entry.getSlot();
 		var person = entry.getTrackedPersonId();
 
+		var actionItems = items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM);
+		var diaryEntryActionItems = actionItems.filter(DiaryEntryActionItem.class::isInstance)//
+				.map(DiaryEntryActionItem.class::cast);
+
 		// First characteristic symptom reported
+		if (entry.getSymptoms().hasCharacteristicSymptom()) {
+			if (actionItems.isEmpty()) {
+				createAndSaveItem(person, entry);
+			} else {
+				var isNewer = diaryEntryActionItems//
+						.filter(it -> it.getEntry().getSlot().compareTo(slot) > 0)//
+						.map(DiaryEntryActionItem::resolve)//
+						.map(items::save).isEmpty();
+				if (!isNewer) {
+					createAndSaveItem(person, entry);
+				}
+			}
+		} else {
+			// resolve action item if the corresponding diary entry was modified
+			var actionResolved = !diaryEntryActionItems.filter(it -> it.getEntry().getSlot().compareTo(slot) == 0)//
+					.map(DiaryEntryActionItem::resolve)//
+					.map(items::save)//
+					.isEmpty();
 
-		if (entry.getSymptoms().hasCharacteristicSymptom() && //
-				items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM).isEmpty()) {
-
-			items.save(new DiaryEntryActionItem(person, entry, ItemType.MEDICAL_INCIDENT,
-					Description.of(DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM)));
+			if (actionResolved) {
+				// search another first diary entry with symptoms when the previous action item was resolved
+				var diary = diaryManagement.findDiaryFor(person);
+				var firstEntryWithSymptoms = diary.stream()//
+						.sorted(Comparator.comparing(DiaryEntry::getSlot))//
+						.filter(it -> it.getSymptoms().hasCharacteristicSymptom())//
+						.findFirst();
+				firstEntryWithSymptoms.ifPresent(it -> createAndSaveItem(person, it));
+			}
 		}
+	}
+
+	private DiaryEntryActionItem createAndSaveItem(TrackedPersonIdentifier person, DiaryEntry entry) {
+		return items.save(new DiaryEntryActionItem(person, entry, ItemType.MEDICAL_INCIDENT,
+				Description.of(DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM)));
 	}
 
 	@EventListener

--- a/backend/src/main/java/quarano/diary/DiaryEntry.java
+++ b/backend/src/main/java/quarano/diary/DiaryEntry.java
@@ -119,6 +119,11 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 	boolean hasSlot(Slot slot) {
 		return this.slot.equals(slot);
 	}
+	
+	public DiaryEntry markEdited() {
+		registerEvent(DiaryEntryUpdated.of(this));
+		return this;
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -151,6 +156,11 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 
 	@Value(staticConstructor = "of")
 	public static class DiaryEntryAdded implements DomainEvent {
+		DiaryEntry entry;
+	}
+	
+	@Value(staticConstructor = "of")
+	public static class DiaryEntryUpdated implements DomainEvent {
 		DiaryEntry entry;
 	}
 }

--- a/backend/src/main/java/quarano/diary/web/DiaryController.java
+++ b/backend/src/main/java/quarano/diary/web/DiaryController.java
@@ -76,7 +76,7 @@ public class DiaryController {
 	}
 
 	@PutMapping("/api/diary/{identifier}")
-	HttpEntity<?> addDiaryEntry(@PathVariable DiaryEntryIdentifier identifier, //
+	HttpEntity<?> updateDiaryEntry(@PathVariable DiaryEntryIdentifier identifier, //
 			@Valid @RequestBody DiaryEntryInput payload, Errors errors, //
 			@LoggedIn TrackedPerson person) {
 

--- a/backend/src/main/java/quarano/diary/web/DiaryRepresentations.java
+++ b/backend/src/main/java/quarano/diary/web/DiaryRepresentations.java
@@ -76,7 +76,7 @@ class DiaryRepresentations {
 	}
 
 	Either<DiaryEntry, Errors> from(DiaryEntryInput input, DiaryEntry existing, Errors errors) {
-		return mapper.map(input, existing, errors);
+		return mapper.map(input, existing, errors).peekLeft(DiaryEntry::markEdited);
 	}
 
 	@Data

--- a/backend/src/test/java/quarano/actions/ActionItemRepositoryIntegrationTests.java
+++ b/backend/src/test/java/quarano/actions/ActionItemRepositoryIntegrationTests.java
@@ -56,8 +56,9 @@ class ActionItemRepositoryIntegrationTests {
 				.resolveAutomatically(repository::save);
 
 		assertThat(repository.findByTrackedPerson(person).stream()) //
-				.has(itemMatching(DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM, false), Index.atIndex(0)) //
-				.has(itemMatching(DescriptionCode.INCREASED_TEMPERATURE, true), Index.atIndex(1));
+				.has(itemMatching(DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM, true), Index.atIndex(0)) //
+				.has(itemMatching(DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM, false), Index.atIndex(1)) //
+				.has(itemMatching(DescriptionCode.INCREASED_TEMPERATURE, true), Index.atIndex(2));
 
 		assertThat(repository.findUnresolvedByTrackedPerson(person).stream()) //
 				.hasSize(1) //

--- a/backend/src/test/java/quarano/actions/DiaryEventListenerTest.java
+++ b/backend/src/test/java/quarano/actions/DiaryEventListenerTest.java
@@ -67,7 +67,7 @@ class DiaryEventListenerTest {
 				.setBodyTemperature(BodyTemperature.of(41F)));
 
 		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> empty()));
-		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
 
 		listener.onDiaryEntryAddedForBodyTemperature(entry);
 
@@ -89,7 +89,7 @@ class DiaryEventListenerTest {
 				.setBodyTemperature(BodyTemperature.of(41F)));
 
 		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> empty()));
-		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
 
 		listener.onDiaryEntryUpdatedForBodyTemperature(entry);
 
@@ -106,7 +106,7 @@ class DiaryEventListenerTest {
 				.setBodyTemperature(BodyTemperature.of(42F)));
 
 		ActionItem actionItem = createMockedActionItem();
-		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
 				.thenReturn(ActionItems.of(actionItem));
 
 		listener.onDiaryEntryUpdatedForBodyTemperature(entry);
@@ -132,7 +132,7 @@ class DiaryEventListenerTest {
 
 		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> of(entry)));
 		ActionItem actionItem = createMockedActionItem();
-		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
 				.thenReturn(ActionItems.of(actionItem));
 
 		listener.onDiaryEntryAddedForBodyTemperature(event);
@@ -153,7 +153,7 @@ class DiaryEventListenerTest {
 				.setSymptoms(List.of(symptom)) //
 				.setBodyTemperature(BodyTemperature.of(36)));
 
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 				.thenReturn(ActionItems.empty());
 
 		listener.onDiaryEntryAddedForCharacteristicSymptoms(event);
@@ -178,7 +178,7 @@ class DiaryEventListenerTest {
 		when(symptom.isCharacteristic()).thenReturn(true);
 
 		var actionItem = createMockedActionItem();
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 				.thenReturn(ActionItems.of(actionItem));
 		when(actionItem.getEntry()).thenReturn(diaryEntry);
 
@@ -207,7 +207,7 @@ class DiaryEventListenerTest {
 
 		when(symptom.isCharacteristic()).thenReturn(true);
 		when(actionItem.getEntry()).thenReturn(DiaryEntry.of(Slot.now(), person));
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 				.thenReturn(ActionItems.of(actionItem));
 
 		// Updates older slot
@@ -237,7 +237,7 @@ class DiaryEventListenerTest {
 		var diaryEntry = DiaryEntry.of(Slot.now(), person);
 
 		when(symptom.isCharacteristic()).thenReturn(true);
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 				.thenReturn(ActionItems.empty());
 
 		// Updates older slot
@@ -272,7 +272,7 @@ class DiaryEventListenerTest {
 		when(symptom.isCharacteristic()).thenReturn(true);
 		when(actionItem.getEntry()).thenReturn(diaryEntry1);
 		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> of(diaryEntry3,diaryEntry2)));
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 				.thenReturn(ActionItems.of(actionItem));
 
 		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry1 //
@@ -294,7 +294,7 @@ class DiaryEventListenerTest {
 		var actionItem = createMockedActionItem();
 		
 		when(actionItem.getEntry()).thenReturn(diaryEntry1);
-		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		when(items.findUnresolvedByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
 		.thenReturn(ActionItems.of(actionItem));
 		
 		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry2 //

--- a/backend/src/test/java/quarano/actions/DiaryEventListenerTest.java
+++ b/backend/src/test/java/quarano/actions/DiaryEventListenerTest.java
@@ -5,8 +5,10 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import quarano.QuaranoUnitTest;
+import quarano.diary.Diary;
 import quarano.diary.DiaryEntry;
 import quarano.diary.DiaryEntryMissing;
+import quarano.diary.DiaryManagement;
 import quarano.diary.Slot;
 import quarano.reference.Symptom;
 import quarano.tracking.BodyTemperature;
@@ -18,23 +20,43 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
+import org.springframework.data.util.Streamable;
 
 @QuaranoUnitTest
 class DiaryEventListenerTest {
 
 	@Mock ActionItemRepository items;
+	@Mock DiaryManagement diaryManagement;
 	@Mock AnomaliesProperties config;
+
+	@Captor ArgumentCaptor<DiaryEntryActionItem> itemCaptor;
 
 	DiaryEventListener listener;
 
 	@BeforeEach
 	void setup() {
 
-		listener = new DiaryEventListener(config, items);
+		listener = new DiaryEventListener(config, items, diaryManagement);
 
 		// stubbing just needed for the diary entry added tests
 		lenient().when(config.getTemperatureThreshold()).thenReturn(BodyTemperature.of(40.99F));
+	}
+
+	@Test
+	void testOnDiaryEntryAddedAndUpdatedAnOlderSlot() {
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+
+		var newerEntry = DiaryEntry.of(Slot.now(), person);
+		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> of(newerEntry)));
+
+		var entryAdded = DiaryEntry.DiaryEntryAdded.of(DiaryEntry.of(Slot.now().previous(), person) //
+				.setBodyTemperature(BodyTemperature.of(41F)));
+
+		listener.onDiaryEntryAddedForBodyTemperature(entryAdded);
+
+		verify(items, times(0)).save(itemCaptor.capture());
 	}
 
 	@Test
@@ -44,9 +66,11 @@ class DiaryEventListenerTest {
 		var entry = DiaryEntry.DiaryEntryAdded.of(DiaryEntry.of(Slot.now(), person) //
 				.setBodyTemperature(BodyTemperature.of(41F)));
 
+		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> empty()));
+		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
+
 		listener.onDiaryEntryAddedForBodyTemperature(entry);
 
-		var itemCaptor = ArgumentCaptor.forClass(DiaryEntryActionItem.class);
 		verify(items, times(1)).save(itemCaptor.capture());
 
 		DiaryEntryActionItem item = itemCaptor.getValue();
@@ -57,16 +81,57 @@ class DiaryEventListenerTest {
 	}
 
 	@Test
+	void testOnDiaryEntryUpdatesWithExceedingTemperature() {
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+
+		// first update with exceeding temperature
+		var entry = DiaryEntry.DiaryEntryUpdated.of(DiaryEntry.of(Slot.now(), person) //
+				.setBodyTemperature(BodyTemperature.of(41F)));
+
+		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> empty()));
+		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE)).thenReturn(ActionItems.empty());
+
+		listener.onDiaryEntryUpdatedForBodyTemperature(entry);
+
+		verify(items, times(1)).save(itemCaptor.capture());
+
+		DiaryEntryActionItem item = itemCaptor.getValue();
+
+		assertThat(item.getType()).isEqualTo(ActionItem.ItemType.MEDICAL_INCIDENT);
+		assertThat(item.getDescription().getArguments()).isEqualTo(new Object[] { "41,0°C", "41,0°C" });
+		assertThat(item.getDescription().getCode()).isEqualTo(DescriptionCode.INCREASED_TEMPERATURE);
+
+		// second update with exceeding temperature
+		entry = DiaryEntry.DiaryEntryUpdated.of(DiaryEntry.of(Slot.now(), person) //
+				.setBodyTemperature(BodyTemperature.of(42F)));
+
+		ActionItem actionItem = createMockedActionItem();
+		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
+				.thenReturn(ActionItems.of(actionItem));
+
+		listener.onDiaryEntryUpdatedForBodyTemperature(entry);
+
+		verify(actionItem, times(1)).resolve();
+		itemCaptor = ArgumentCaptor.forClass(DiaryEntryActionItem.class);
+		verify(items, times(3)).save(itemCaptor.capture());
+
+		item = itemCaptor.getValue();
+
+		assertThat(item.getType()).isEqualTo(ActionItem.ItemType.MEDICAL_INCIDENT);
+		assertThat(item.getDescription().getArguments()).isEqualTo(new Object[] { "42,0°C", "41,0°C" });
+		assertThat(item.getDescription().getCode()).isEqualTo(DescriptionCode.INCREASED_TEMPERATURE);
+	}
+
+	@Test
 	void testOnDiaryEntryAddedWithExceedingTemperatureResolved() {
 
 		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
-		var event = DiaryEntry.DiaryEntryAdded.of(DiaryEntry.of(Slot.now(), person) //
+		DiaryEntry entry = DiaryEntry.of(Slot.now(), person);
+		var event = DiaryEntry.DiaryEntryAdded.of(entry //
 				.setBodyTemperature(BodyTemperature.of(39F)));
 
-		var actionItem = mock(ActionItem.class);
-		when(actionItem.isUnresolved()).thenReturn(true);
-		when(actionItem.resolve()).thenReturn(actionItem);
-
+		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> of(entry)));
+		ActionItem actionItem = createMockedActionItem();
 		when(items.findByDescriptionCode(person, DescriptionCode.INCREASED_TEMPERATURE))
 				.thenReturn(ActionItems.of(actionItem));
 
@@ -93,7 +158,6 @@ class DiaryEventListenerTest {
 
 		listener.onDiaryEntryAddedForCharacteristicSymptoms(event);
 
-		var itemCaptor = ArgumentCaptor.forClass(DiaryEntryActionItem.class);
 		verify(items, times(1)).save(itemCaptor.capture());
 		DiaryEntryActionItem item = itemCaptor.getValue();
 		assertThat(item.getType()).isEqualTo(ActionItem.ItemType.MEDICAL_INCIDENT);
@@ -101,20 +165,143 @@ class DiaryEventListenerTest {
 	}
 
 	@Test
-	void testOnDiaryEntryAddedWithCharacteristicSymptomsNotOverwritingExisting() {
+	void testOnDiaryEntryWithSymptomsNotOverwritingExistingIfNewerOrEquals() {
 
+		// Updates equal slot
 		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
 		var symptom = mock(Symptom.class);
-		var event = DiaryEntry.DiaryEntryAdded.of(DiaryEntry.of(Slot.now(), person) //
+		var diaryEntry = DiaryEntry.of(Slot.now(), person);
+		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry //
 				.setSymptoms(List.of(symptom)) //
 				.setBodyTemperature(BodyTemperature.of(36)));
 
 		when(symptom.isCharacteristic()).thenReturn(true);
+
+		var actionItem = createMockedActionItem();
 		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
-				.thenReturn(ActionItems.of(mock(DiaryEntryActionItem.class)));
+				.thenReturn(ActionItems.of(actionItem));
+		when(actionItem.getEntry()).thenReturn(diaryEntry);
 
-		listener.onDiaryEntryAddedForCharacteristicSymptoms(event);
+		listener.onDiaryEntryUpdatedForCharacteristicSymptoms(event);
 
+		verify(items, times(0)).save(any());
+
+		// Addes newer slot
+		when(actionItem.getEntry()).thenReturn(DiaryEntry.of(Slot.now().previous(), person));
+
+		var event2 = DiaryEntry.DiaryEntryAdded.of(diaryEntry //
+				.setSymptoms(List.of(symptom)) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryAddedForCharacteristicSymptoms(event2);
+
+		verify(items, times(0)).save(any());
+	}
+
+	@Test
+	void testOnDiaryEntryWithSymptomsOverwritingExistingIfOlder() {
+
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+		var symptom = mock(Symptom.class);
+		var diaryEntry = DiaryEntry.of(Slot.now().previous(), person);
+		var actionItem = createMockedActionItem();
+
+		when(symptom.isCharacteristic()).thenReturn(true);
+		when(actionItem.getEntry()).thenReturn(DiaryEntry.of(Slot.now(), person));
+		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+				.thenReturn(ActionItems.of(actionItem));
+
+		// Updates older slot
+		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry //
+				.setSymptoms(List.of(symptom)) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryUpdatedForCharacteristicSymptoms(event);
+
+		verify(items, times(2)).save(itemCaptor.capture());
+		assertThat(itemCaptor.getAllValues()).contains(actionItem);
+
+		// Addes older slot
+		var event2 = DiaryEntry.DiaryEntryAdded.of(diaryEntry //
+				.setSymptoms(List.of(symptom)) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryAddedForCharacteristicSymptoms(event2);
+
+		verify(items, times(4)).save(itemCaptor.capture());
+		assertThat(itemCaptor.getAllValues()).contains(actionItem);
+	}
+
+	@Test
+	void testOnDiaryEntryWithSymptomsForFirstActionItem() {
+
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+		var symptom = mock(Symptom.class);
+		var diaryEntry = DiaryEntry.of(Slot.now(), person);
+
+		when(symptom.isCharacteristic()).thenReturn(true);
+		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+				.thenReturn(ActionItems.empty());
+
+		// Updates older slot
+		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry //
+				.setSymptoms(List.of(symptom)) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryUpdatedForCharacteristicSymptoms(event);
+
+		verify(items, times(1)).save(itemCaptor.capture());
+		assertThat(itemCaptor.getValue().getEntry()).isEqualTo(diaryEntry);
+
+		// Addes older slot
+		var event2 = DiaryEntry.DiaryEntryAdded.of(diaryEntry //
+				.setSymptoms(List.of(symptom)) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryAddedForCharacteristicSymptoms(event2);
+
+		verify(items, times(2)).save(itemCaptor.capture());
+		assertThat(itemCaptor.getValue().getEntry()).isEqualTo(diaryEntry);
+	}
+
+	@Test
+	void testOnDiaryEntryUpdatedNewWithoutSymptomsResolvesActionItemAndCreateNewOne() {
+
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+		var symptom = mock(Symptom.class);
+		var diaryEntry3 = DiaryEntry.of(Slot.now(), person).setSymptoms(List.of(symptom));
+		var diaryEntry2 = DiaryEntry.of(Slot.now().previous(), person).setSymptoms(List.of(symptom));
+		var diaryEntry1 = DiaryEntry.of(Slot.now().previous().previous(), person);
+		var actionItem = createMockedActionItem();
+
+		when(symptom.isCharacteristic()).thenReturn(true);
+		when(actionItem.getEntry()).thenReturn(diaryEntry1);
+		when(diaryManagement.findDiaryFor(person)).thenReturn(Diary.of(Streamable.<DiaryEntry> of(diaryEntry3,diaryEntry2)));
+		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+				.thenReturn(ActionItems.of(actionItem));
+
+		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry1 //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryUpdatedForCharacteristicSymptoms(event);
+
+		verify(items, times(2)).save(itemCaptor.capture());
+		List<DiaryEntryActionItem> allValues = itemCaptor.getAllValues();
+		assertThat(allValues.get(0)).isEqualTo(actionItem);
+		assertThat(allValues.get(1).getEntry()).isEqualTo(diaryEntry2);
+	}
+	
+	@Test
+	void testOnDiaryEntryUpdatedAgainWithoutSymptomsDoNothing() {
+		
+		var person = TrackedPersonIdentifier.of(UUID.randomUUID());
+		var diaryEntry2 = DiaryEntry.of(Slot.now(), person);
+		var diaryEntry1 = DiaryEntry.of(Slot.now().previous(), person);
+		var actionItem = createMockedActionItem();
+		
+		when(actionItem.getEntry()).thenReturn(diaryEntry1);
+		when(items.findByDescriptionCode(person, DescriptionCode.FIRST_CHARACTERISTIC_SYMPTOM))
+		.thenReturn(ActionItems.of(actionItem));
+		
+		var event = DiaryEntry.DiaryEntryUpdated.of(diaryEntry2 //
+				.setSymptoms(List.of()) //
+				.setBodyTemperature(BodyTemperature.of(36)));
+		listener.onDiaryEntryUpdatedForCharacteristicSymptoms(event);
+		
 		verify(items, times(0)).save(any());
 	}
 
@@ -138,5 +325,12 @@ class DiaryEventListenerTest {
 		assertThat(itemCaptor.getAllValues()).hasSize(1);
 		assertThat(itemCaptor.getValue().getSlot()).isEqualTo(slots.get(0));
 		assertThat(itemCaptor.getValue().getDescription().getCode()).isEqualTo(DescriptionCode.DIARY_ENTRY_MISSING);
+	}
+
+	private DiaryEntryActionItem createMockedActionItem() {
+		var actionItem = mock(DiaryEntryActionItem.class);
+		lenient().when(actionItem.isUnresolved()).thenReturn(true);
+		lenient().when(actionItem.resolve()).thenReturn(actionItem);
+		return actionItem;
 	}
 }

--- a/backend/src/test/java/quarano/actions/web/ActionItemsControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/actions/web/ActionItemsControllerWebIntegrationTests.java
@@ -68,7 +68,9 @@ class ActionItemsControllerWebIntegrationTests {
 		var document = JsonPath.parse(response);
 
 		assertThat(document.read("$.comments", JSONArray.class)).isEmpty();
-		assertThat(document.read("$.anomalies.resolved", JSONArray.class)).isEmpty();
+		assertThat(document.read("$.anomalies.health", JSONArray.class)).hasSize(1);
+		assertThat(document.read("$.anomalies.resolved", JSONArray.class)).hasSize(1);
+		assertThat(document.read("$.anomalies.resolved[0].items", JSONArray.class)).hasSize(2);
 	}
 
 	@Test


### PR DESCRIPTION
CORE-222 - Fieber von Kontakt Fall nicht in Aktionsübersicht

The DiaryEntryActionItem was created after a DiaryEntryAdded event but
there was no update event. Now an DiaryEntryUpdate event is registered
for changes to the entry and this event is handled.

This handling is implemented for critical temperature and characteristic
symptoms.

Adds several tests for the DiaryEntry event handling for temperature and
symptoms.

Task-Url: https://jira.quarano.de/browse/CORE-222