### PR TITLE
Implements validation of quarantine dates

### DIFF
--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -190,6 +190,8 @@ class TrackedCaseRepresentations implements ExternalTrackedCaseRepresentations {
 
 		if (type.equals(CaseType.INDEX) || payload.getTestDate() != null) {
 			validationGroups.add(ValidationGroups.Index.class);
+		} else if (payload.getQuarantineStartDate() != null || payload.getQuarantineEndDate() != null) {
+			validationGroups.add(ValidationGroups.Contact.class);
 		}
 
 		return errors //
@@ -225,8 +227,8 @@ class TrackedCaseRepresentations implements ExternalTrackedCaseRepresentations {
 		private @Pattern(regexp = Strings.NAMES) @NotEmpty String firstName;
 		private @Pattern(regexp = Strings.EXT_REFERENCE_NUMBER) String extReferenceNumber;
 		private @NotNull(groups = ValidationGroups.Index.class) LocalDate testDate;
-		private @NotNull(groups = ValidationGroups.Index.class) LocalDate quarantineStartDate;
-		private @NotNull(groups = ValidationGroups.Index.class) LocalDate quarantineEndDate;
+		private @NotNull(groups = {ValidationGroups.Index.class, ValidationGroups.Contact.class}) LocalDate quarantineStartDate;
+		private @NotNull(groups = {ValidationGroups.Index.class, ValidationGroups.Contact.class}) LocalDate quarantineEndDate;
 
 		private @Pattern(regexp = Strings.STREET) String street;
 		private @Pattern(regexp = Strings.HOUSE_NUMBER) String houseNumber;
@@ -240,6 +242,10 @@ class TrackedCaseRepresentations implements ExternalTrackedCaseRepresentations {
 
 		Errors validate(Errors errors, CaseType type) {
 
+			if (quarantineStartDate != null && quarantineEndDate != null && quarantineStartDate.isAfter(quarantineEndDate)) {
+				errors.rejectValue("quarantineEndDate", "EndBeforeStart");
+			}
+			
 			if (type.equals(CaseType.CONTACT)) {
 				return errors;
 			}

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -70,6 +70,7 @@ NotNull.quarantineEndDate=Bitte geben Sie ein gültiges Enddatum der Quarantäne
 PhoneOrMobile.mobilePhone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
 PhoneOrMobile.phone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
 ContactCase.infected=Ein Kontaktfall darf nicht infiziert sein.
+EndBeforeStart.quarantineEndDate=Bitte geben Sie ein Enddatum ein, welches nach dem Startdatum liegt.
 
 quarano.department.CaseStatus.opened=angelegt
 quarano.department.CaseStatus.in-registration=in Registrierung


### PR DESCRIPTION
The quarantine Start must be always before or equals the end.
For contacts, the quarantine start and end dates must be defined
together now. Or neither of them may be set.