### PR TITLE
CORE-258 - Creates contact cases for contacts of converted index cases.

### DIFF
--- a/backend/src/main/java/quarano/actions/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/actions/TrackedCaseEventListener.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
  * @author Oliver Drotbohm
  */
 @Slf4j
-@Component
+@Component("actions.TrackedCaseEventListener")
 @RequiredArgsConstructor
 class TrackedCaseEventListener {
 

--- a/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
@@ -1,0 +1,50 @@
+package quarano.department;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import quarano.account.Department;
+import quarano.department.TrackedCase.CaseConvertedToIndex;
+import quarano.tracking.ContactPerson;
+import quarano.tracking.Encounter;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Slf4j
+@Component("department.TrackedCaseEventListener")
+@RequiredArgsConstructor
+class TrackedCaseEventListener {
+
+	private final @NonNull TrackedCaseRepository cases;
+
+	@EventListener
+	void on(CaseConvertedToIndex event) {
+
+		var trackedCase = event.getTrackedCase();
+		var department = trackedCase.getDepartment();
+
+		// Only contacts of index-cases shall be converted to new cases automatically
+		if (!trackedCase.isIndexCase()) {
+			return;
+		}
+
+		trackedCase.getTrackedPerson().getEncounters()//
+				.map(Encounter::getContact)//
+				.forEach(it -> createContactCase(department, it));
+	}
+
+	private void createContactCase(Department department, ContactPerson contactPerson) {
+
+		if (cases.existsByOriginContacts(contactPerson)) {
+			return;
+		}
+
+		cases.save(TrackedCase.of(contactPerson, department));
+
+		log.info("Created automatic contact case from contact " + contactPerson.getId());
+	}
+}

--- a/backend/src/main/java/quarano/department/TrackingEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackingEventListener.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import quarano.diary.DiaryManagement;
 import quarano.tracking.ContactPerson;
-import quarano.tracking.TrackedPerson;
 import quarano.tracking.TrackedPerson.EncounterReported;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 import quarano.tracking.TrackedPersonRepository;
@@ -78,18 +77,8 @@ public class TrackingEventListener {
 		if (!caseOfContactInitializer.isIndexCase()) {
 			return;
 		}
-
-		var person = new TrackedPerson(contactPerson);
-		var caseType = CaseType.CONTACT;
-
-		// CORE-185 medical staff overwrites the others
-		if (contactPerson.getIsHealthStaff() == Boolean.TRUE) {
-			caseType = CaseType.CONTACT_MEDICAL;
-		} else if (contactPerson.isVulnerable()) {
-			caseType = CaseType.CONTACT_VULNERABLE;
-		}
-
-		cases.save(new TrackedCase(person, caseType, caseOfContactInitializer.getDepartment(), contactPerson));
+			
+		cases.save(TrackedCase.of(contactPerson, caseOfContactInitializer.getDepartment()));
 
 		log.info("Created automatic contact case from contact " + contactPerson.getId());
 	}

--- a/backend/src/test/java/quarano/department/TrackedCaseEventListenerTests.java
+++ b/backend/src/test/java/quarano/department/TrackedCaseEventListenerTests.java
@@ -1,0 +1,134 @@
+package quarano.department;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import quarano.QuaranoUnitTest;
+import quarano.account.Department;
+import quarano.department.TrackedCase.CaseConvertedToIndex;
+import quarano.tracking.ContactPerson;
+import quarano.tracking.ContactWays;
+import quarano.tracking.Encounter;
+import quarano.tracking.TrackedPerson;
+import quarano.tracking.TrackedPersonDataInitializer;
+
+/**
+ * @author Jens Kutzsche
+ */
+@QuaranoUnitTest
+class TrackedCaseEventListenerTests {
+
+	private static final String MAX = "Max";
+	private static final String MORITZ = "Moritz";
+	private static final String MUSTERMANN = "Mustermann";
+	private static final String MANNHEIM = "Mannheim";
+	
+	private static final String FIRST_NAME = "trackedPerson.firstName";
+	private static final String LAST_NAME = "trackedPerson.lastName";
+	private static final String DEPARTMENT_NAME = "department.name";
+
+	@Mock TrackedCaseRepository cases;
+
+	@Captor ArgumentCaptor<TrackedCase> captor;
+
+	private TrackedCaseEventListener listener;
+
+	@BeforeEach
+	void setup() {
+
+		listener = new TrackedCaseEventListener(cases);
+	}
+
+	@Test
+	void testIgnoreNonIndexCase() {
+
+		var contactDate = LocalDate.now();
+		var person = TrackedPersonDataInitializer.createTanja();
+		createEncounterWithMaxFor(person, contactDate);
+		createEncounterWithMoritzFor(person, contactDate);
+		var trackedCase = createCaseFor(person, CaseType.CONTACT);
+
+		listener.on(CaseConvertedToIndex.of(trackedCase));
+
+		verify(cases, never()).save(any());
+	}
+
+	@Test
+	void testCreateContactCase() {
+
+		var contactDate = LocalDate.now().minusDays(5);
+		var person = TrackedPersonDataInitializer.createTanja();
+		var trackedCase = createCaseFor(person, CaseType.INDEX);
+		createEncounterWithMaxFor(person, contactDate);
+		createEncounterWithMoritzFor(person, contactDate);
+
+		listener.on(CaseConvertedToIndex.of(trackedCase));
+
+		verify(cases, times(2)).save(captor.capture());
+
+		assertThat(captor.getAllValues()).hasSize(2)//
+				.extracting(FIRST_NAME, LAST_NAME, DEPARTMENT_NAME)//
+				.containsOnly(tuple(MAX, MUSTERMANN, MANNHEIM), tuple(MORITZ, MUSTERMANN, MANNHEIM));
+	}
+
+	@Test
+	void testCreateNoDuplicateCase() {
+
+		var contactDate = LocalDate.now();
+		var person = TrackedPersonDataInitializer.createTanja();
+		var encounter = createEncounterWithMaxFor(person, contactDate);
+		var trackedCase = createCaseFor(person, CaseType.INDEX);
+
+		person.reportContactWith(encounter.getContact(), contactDate.minusDays(1));
+		person.reportContactWith(encounter.getContact(), contactDate.minusDays(2));
+
+		when(cases.existsByOriginContacts(encounter.getContact())).thenReturn(false, true, true);
+
+		listener.on(CaseConvertedToIndex.of(trackedCase));
+
+		verify(cases, times(1)).save(captor.capture());
+		verify(cases, times(3)).existsByOriginContacts(encounter.getContact());
+
+		assertThat(captor.getAllValues()).hasSize(1)//
+				.extracting(FIRST_NAME, LAST_NAME, DEPARTMENT_NAME)//
+				.containsOnly(tuple(MAX, MUSTERMANN, MANNHEIM));
+	}
+
+	private Encounter createEncounterWithMaxFor(TrackedPerson person, LocalDate date) {
+
+		var contactWays = ContactWays.ofEmailAddress("max@mustermann.de");
+		var contactPerson = new ContactPerson(MAX, MUSTERMANN, contactWays) //
+				.assignOwner(person);
+
+		return person.reportContactWith(contactPerson, date);
+	}
+
+	private Encounter createEncounterWithMoritzFor(TrackedPerson person, LocalDate date) {
+
+		var contactWays = ContactWays.ofEmailAddress("moritz@mustermann.de");
+		var contactPerson = new ContactPerson(MORITZ, MUSTERMANN, contactWays) //
+				.assignOwner(person);
+
+		return person.reportContactWith(contactPerson, date);
+	}
+
+	private TrackedCase createCaseFor(TrackedPerson person, CaseType type) {
+
+		return new TrackedCase(person, type, new Department(MANNHEIM)) //
+				.submitEnrollmentDetails() //
+				.submitQuestionnaire(new MinimalQuestionnaire());
+	}
+}


### PR DESCRIPTION
When a contact case is converted to an index case, a new contact case is
created for all his contacts.

An event is used to separate changing the status of a case and
converting its contacts.

Adds an of-method to create a TrackedCase from a ContactPerson to avoid
code duplication.

https://quarano.atlassian.net/browse/CORE-258