### PR TITLE
Fix setup-cf-cli action settings

### DIFF
--- a/.github/workflows/backend-develop.yml
+++ b/.github/workflows/backend-develop.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Set up CF CLI
       if: success()
-      uses: jvalkeal/setup-cf-cli-action@master
+      uses: jvalkeal/setup-cf-cli@v0
       with:
         version: 6.51.0
 

--- a/.github/workflows/backend-security.yml
+++ b/.github/workflows/backend-security.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Set up CF CLI
       if: success()
-      uses: jvalkeal/setup-cf-cli-action@master
+      uses: jvalkeal/setup-cf-cli@v0
       with:
         version: 6.51.0
 

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Set up CF CLI
       if: success()
-      uses: jvalkeal/setup-cf-cli-action@master
+      uses: jvalkeal/setup-cf-cli@v0
       with:
         version: 6.51.0
 

--- a/.github/workflows/frontend-develop.yml
+++ b/.github/workflows/frontend-develop.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set up CF CLI
         if: success()
-        uses: jvalkeal/setup-cf-cli-action@master
+        uses: jvalkeal/setup-cf-cli@v0
         with:
           version: 6.51.0
 

--- a/.github/workflows/frontend-sec.yml
+++ b/.github/workflows/frontend-sec.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up CF CLI
         if: success()
-        uses: jvalkeal/setup-cf-cli-action@master
+        uses: jvalkeal/setup-cf-cli@v0
         with:
           version: 6.51.0
       - name: CF Login

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up CF CLI
         if: success()
-        uses: jvalkeal/setup-cf-cli-action@master
+        uses: jvalkeal/setup-cf-cli@v0
         with:
           version: 6.51.0
 


### PR DESCRIPTION
- Master version should not be use unless
  you want to live dangerously.
- Master is anyway going to stop working as default
  branch is going to get renamed to main.
- Recently repo got renamed and `-action` got stripped
  from a repo name, it currently works because of gh
  automatic redirects.
- Version `v0` is going to always resolve to latest stable
  release from that serie.