### PR TITLE
GOM-354 Add self link in tracked case dto.

### DIFF
--- a/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
@@ -7,6 +7,8 @@ import org.springframework.hateoas.LinkRelation;
  */
 public class TrackedCaseLinkRelations {
 
+	public static final LinkRelation SELF = LinkRelation.of("self");
+
 	public static final LinkRelation START_TRACKING = LinkRelation.of("start-tracking");
 	public static final LinkRelation CONCLUDE = LinkRelation.of("conclude");
 	public static final LinkRelation RENEW = LinkRelation.of("renew");

--- a/backend/src/main/java/quarano/department/web/TrackedCaseStatusAware.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseStatusAware.java
@@ -37,7 +37,10 @@ public class TrackedCaseStatusAware<T extends RepresentationModel<T>> extends Re
 
 		var controller = on(TrackedCaseController.class);
 
-		var links = Links.of(Link.of(fromMethodCall(controller.concludeCase(trackedCase.getId(), null)).toUriString(),
+		var links = Links.of(Link.of(fromMethodCall(controller.getCase(trackedCase.getId(), null)).toUriString(),
+				TrackedCaseLinkRelations.SELF));
+
+		links = links.and(Link.of(fromMethodCall(controller.concludeCase(trackedCase.getId(), null)).toUriString(),
 				TrackedCaseLinkRelations.CONCLUDE));
 
 		links = links.and(Link.of(fromMethodCall(controller.getContactsOfCase(trackedCase.getId(), null)).toUriString(),

--- a/backend/src/test/java/quarano/department/web/TrackedCaseControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/TrackedCaseControllerWebIntegrationTests.java
@@ -531,6 +531,19 @@ class TrackedCaseControllerWebIntegrationTests {
 		assertThat(document.read("$.belongToMedicalStaffDescription", String.class)).isNotNull();
 	}
 
+	@Test // CORE-354
+	void exposesSelfLink() throws Exception {
+
+		var trackingCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_SEC1_ID_DEP1).orElseThrow();
+
+		var response = mvc.perform(get("/api/hd/cases/{id}", trackingCase.getId()))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+		var link = discoverer.findRequiredLinkWithRel(SELF, response);
+		assertThat(link).isNotNull();
+	}
+
 	@Test // CORE-119
 	@SuppressWarnings("unchecked")
 	void exposesContactsForCase() throws Exception {


### PR DESCRIPTION
As it is planned to use self links as IDs in the future the tracked case dto links should contain a self link too.