### PR TITLE
Feature/core 355 mehrsprachigkeit backend

### DIFF
--- a/backend/src/main/java/quarano/Quarano.java
+++ b/backend/src/main/java/quarano/Quarano.java
@@ -20,10 +20,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.core.PriorityOrdered;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.env.Environment;
@@ -87,11 +85,6 @@ public class Quarano {
 				.forEach(it -> it.customize(mapper));
 
 		return mapper;
-	}
-
-	@Bean
-	MessageSourceAccessor messageSourceAccessor(MessageSource source) {
-		return new MessageSourceAccessor(source);
 	}
 
 	/**

--- a/backend/src/main/java/quarano/core/ConfigurableEmailTemplates.java
+++ b/backend/src/main/java/quarano/core/ConfigurableEmailTemplates.java
@@ -84,7 +84,7 @@ class ConfigurableEmailTemplates implements EmailTemplates {
 				var resourceDefault = getFirstExistingResource(templates.get(key), List.of(""));
 				var templateDefault = readTemplate(resourceDefault);
 
-				return String.format("%s\n\n==========\n\n%s", template, templateDefault);
+				return String.join("\r\n\r\n==========\r\n\r\n", template, templateDefault);
 
 			} else {
 				return template;

--- a/backend/src/main/java/quarano/core/ConfigurableEmailTemplates.java
+++ b/backend/src/main/java/quarano/core/ConfigurableEmailTemplates.java
@@ -1,15 +1,28 @@
 package quarano.core;
 
-import java.io.IOException;
+import io.vavr.Tuple;
+import io.vavr.control.Try;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
 
@@ -18,29 +31,35 @@ import org.springframework.util.Assert;
  * {@link ResourceLoader}.
  *
  * @author Oliver Drotbohm
+ * @author Jens Kutzsche
  */
 class ConfigurableEmailTemplates implements EmailTemplates {
 
+	static final Locale DEFAULT_LOCALE = Locale.GERMANY;
+
 	private final ResourceLoader resources;
 	private final Map<Key, String> templates;
-	private final Map<Key, String> cache;
+	private final Map<Tuple, String> cache;
+	private final String pathTemplate;
 
 	/**
 	 * Creates a new {@link ConfigurableEmailTemplates} for the given {@link ResourceLoader}, {@link Stream} of template
-	 * {@link Key}s and a file template to turn the keys into actual files accessible for the {@link ResourceLoader}.
+	 * {@link Key}s and a path template to turn the keys into actual files accessible for the {@link ResourceLoader}. In
+	 * the path template use <b>%1$s for file name</b> and <b>%2$s for language tage</b>.
 	 *
 	 * @param resources must not be {@literal null}.
 	 * @param keys must not be {@literal null}.
-	 * @param fileTemplate must not be {@literal null} or empty.
+	 * @param pathTemplate must not be {@literal null} or empty.
 	 */
-	public ConfigurableEmailTemplates(ResourceLoader resources, Stream<Key> keys, String fileTemplate) {
+	public ConfigurableEmailTemplates(ResourceLoader resources, Stream<Key> keys, String pathTemplate) {
 
 		Assert.notNull(resources, "ResourceLoader must not be null!");
 		Assert.notNull(keys, "Keys must not be null!");
-		Assert.hasText(fileTemplate, "File template must not be null or empty!");
+		Assert.hasText(pathTemplate, "File template must not be null or empty!");
 
 		this.resources = resources;
-		this.templates = keys.collect(Collectors.toMap(Function.identity(), it -> it.toFileName(fileTemplate)));
+		this.templates = keys.collect(Collectors.toMap(Function.identity(), Key::toFileName));
+		this.pathTemplate = pathTemplate;
 		this.cache = new ConcurrentHashMap<>(templates.size());
 	}
 
@@ -49,25 +68,105 @@ class ConfigurableEmailTemplates implements EmailTemplates {
 	 * @see quarano.core.EmailTemplates#expandTemplate(quarano.core.EmailTemplates.Key, java.util.Map)
 	 */
 	@Override
-	public String expandTemplate(Key key, Map<String, Object> placeholders) {
+	public String expandTemplate(Key key, Map<String, Object> placeholders, Locale locale) {
 
-		var template = cache.computeIfAbsent(key, it -> {
+		var cacheKey = Tuple.of(key, locale);
+		var text = cache.computeIfAbsent(cacheKey, __ -> {
 
-			var location = templates.get(key);
-			var resource = resources.getResource(location);
+			var localeTags = createLocaleTags(locale);
+			var resource = getFirstExistingResource(templates.get(key), localeTags);
+			var template = readTemplate(resource);
 
-			try {
-				var path = resource.getFile().getPath();
-				return Files.readString(Path.of(path));
-			} catch (IOException o_O) {
-				throw new IllegalStateException("Could not read file " + location + "!", o_O);
+			String localeTag = resource.getLocaleTag();
+
+			if (StringUtils.isNotBlank(localeTag) && !localeTag.startsWith(DEFAULT_LOCALE.getLanguage())) {
+
+				var resourceDefault = getFirstExistingResource(templates.get(key), List.of(""));
+				var templateDefault = readTemplate(resourceDefault);
+
+				return String.format("%s\n\n==========\n\n%s", template, templateDefault);
+
+			} else {
+				return template;
 			}
 		});
 
 		for (Entry<String, Object> replacement : placeholders.entrySet()) {
-			template = template.replace(String.format("{%s}", replacement.getKey()), replacement.getValue().toString());
+			text = text.replace(String.format("{%s}", replacement.getKey()), replacement.getValue().toString());
 		}
 
-		return template;
+		return text;
+	}
+
+	private ArrayList<String> createLocaleTags(Locale locale) {
+
+		var localeTags = new ArrayList<String>(4);
+
+		localeTags.add(""); // fallback
+
+		if (locale != null) {
+
+			var joiner = new StringJoiner("_");
+
+			var language = locale.getLanguage();
+			if (StringUtils.isNoneBlank(language)) {
+
+				joiner.add(language);
+				localeTags.add(0, joiner.toString());
+			}
+
+			var country = locale.getCountry();
+			if (StringUtils.isNoneBlank(country)) {
+
+				joiner.add(country);
+				localeTags.add(0, joiner.toString());
+			}
+
+			var variant = locale.getVariant();
+			if (StringUtils.isNoneBlank(variant)) {
+
+				joiner.add(variant);
+				localeTags.add(0, joiner.toString());
+			}
+		}
+
+		return localeTags;
+	}
+
+	private LocaleResource getFirstExistingResource(String templateName, List<String> localeTags) {
+
+		return localeTags.stream()
+				.map(LocaleResource::of)
+				.map(it -> it.withPath(String.format(pathTemplate, templateName, it.getLocaleTag())))
+				.map(it -> it.withResource(resources.getResource(it.getPath())))
+				.filter(it -> it.getResource().exists())
+				.findFirst()
+				.orElseThrow(() -> {
+
+					var localeTagsStr = "[" + String.join("|", localeTags) + "]";
+					return new IllegalStateException("Could not find any of the template files "
+							+ String.format(pathTemplate, templateName, localeTagsStr) + "!");
+				});
+	}
+
+	private String readTemplate(LocaleResource resource) {
+
+		return Try.of(() -> resource.getResource().getFile().getPath())
+				.map(Path::of)
+				.mapTry(Files::readString)
+				.getOrElseThrow(o_O -> new IllegalStateException("Could not read file " + resource.getPath() + "!", o_O));
+	}
+
+	@RequiredArgsConstructor(staticName = "of")
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	private static class LocaleResource {
+		@Getter
+		final String localeTag;
+		@With
+		@Getter
+		String path;
+		@With
+		@Getter
+		Resource resource;
 	}
 }

--- a/backend/src/main/java/quarano/core/CoreConfiguration.java
+++ b/backend/src/main/java/quarano/core/CoreConfiguration.java
@@ -16,6 +16,6 @@ class CoreConfiguration {
 
 	@Bean
 	ConfigurableEmailTemplates emailTemplates(ResourceLoader loader) {
-		return new ConfigurableEmailTemplates(loader, Keys.stream(), "classpath:masterdata/templates/%s");
+		return new ConfigurableEmailTemplates(loader, Keys.stream(), "classpath:masterdata/templates/%2$s/%1$s");
 	}
 }

--- a/backend/src/main/java/quarano/core/EmailSender.java
+++ b/backend/src/main/java/quarano/core/EmailSender.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.springframework.boot.autoconfigure.mail.MailProperties;
@@ -120,6 +121,7 @@ public class EmailSender {
 		private final @Getter String subject;
 		private final Key template;
 		private final Map<String, ? extends Object> placeholders;
+		private final Locale locale;
 
 		/*
 		 * (non-Javadoc)
@@ -151,7 +153,7 @@ public class EmailSender {
 			placeholders.put("host", configuration.getHost());
 			placeholders.putAll(this.placeholders);
 
-			return templates.expandTemplate(template, placeholders);
+			return templates.expandTemplate(template, placeholders, locale);
 		}
 
 		private interface InternetAdressSource {

--- a/backend/src/main/java/quarano/core/EmailTemplates.java
+++ b/backend/src/main/java/quarano/core/EmailTemplates.java
@@ -7,22 +7,25 @@ import java.util.stream.Stream;
 
 /**
  * @author Oliver Drotbohm
+ * @author Jens Kutzsche
  */
 public interface EmailTemplates {
 
 	/**
-	 * Expands the template with the given {@link Key} and placeholders.
+	 * Expands the template with the given {@link Key} and placeholders in the language of the given locale.
 	 *
 	 * @param key must not be {@literal null}.
 	 * @param placeholders must not be {@literal null}.
+	 * @param locale can be {@literal null}.
 	 * @return will never be {@literal null}.
 	 */
-	String expandTemplate(Key key, Map<String, Object> placeholders);
+	String expandTemplate(Key key, Map<String, Object> placeholders, Locale locale);
 
 	/**
 	 * A template key.
 	 *
 	 * @author Oliver Drotbohm
+	 * @author Jens Kutzsche
 	 */
 	interface Key {
 
@@ -30,16 +33,16 @@ public interface EmailTemplates {
 		 * Resolves the current {@link Key} to a file that can be loaded via a
 		 * {@link org.springframework.core.io.ResourceLoader}.
 		 *
-		 * @param pattern must not be {@literal null} or empty.
 		 * @return
 		 */
-		String toFileName(String pattern);
+		String toFileName();
 	}
 
 	/**
 	 * Predefined keys to be usable with the application.
 	 *
 	 * @author Oliver Drotbohm
+	 * @author Jens Kutzsche
 	 */
 	enum Keys implements Key {
 
@@ -56,14 +59,11 @@ public interface EmailTemplates {
 
 		/*
 		 * (non-Javadoc)
-		 * @see quarano.core.EmailTemplates.Key#toFileName(java.lang.String)
+		 * @see quarano.core.EmailTemplates.Key#toFileName()
 		 */
 		@Override
-		public String toFileName(String pattern) {
-
-			var localName = name().toLowerCase(Locale.US).replace('_', '-').concat(".txt");
-
-			return String.format(pattern, localName);
+		public String toFileName() {
+			return name().toLowerCase(Locale.US).replace('_', '-').concat(".txt");
 		}
 	}
 }

--- a/backend/src/main/java/quarano/core/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/core/LocaleConfiguration.java
@@ -38,6 +38,10 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 @RequiredArgsConstructor
 public class LocaleConfiguration {
 
+	public static final List<Locale> LOCALES = List.of(
+			new Locale("en"),
+			new Locale("tr"));
+
 	private final @NonNull AuthenticationManager accounts;
 	private final @NonNull TrackedPersonRepository persons;
 
@@ -56,10 +60,6 @@ public class LocaleConfiguration {
 	 * header.
 	 */
 	class LocaleResolver extends AcceptHeaderLocaleResolver {
-
-		final List<Locale> LOCALES = List.of(
-				new Locale("en"),
-				new Locale("tr"));
 
 		@Override
 		public Locale resolveLocale(HttpServletRequest request) {

--- a/backend/src/main/java/quarano/core/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/core/LocaleConfiguration.java
@@ -1,0 +1,108 @@
+package quarano.core;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import quarano.account.AuthenticationManager;
+import quarano.tracking.TrackedPerson;
+import quarano.tracking.TrackedPersonRepository;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.LocaleUtils;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+/**
+ * Configuration class for locale and message related matters.
+ *
+ * @author Jens Kutzsche
+ */
+@Configuration(proxyBeanMethods = false)
+@RequiredArgsConstructor
+public class LocaleConfiguration {
+
+	private final @NonNull AuthenticationManager accounts;
+	private final @NonNull TrackedPersonRepository persons;
+
+	@Bean
+	LocaleResolver localeResolver() {
+		return new LocaleResolver();
+	}
+
+	@Bean
+	MessageSourceAccessor messageSourceAccessor(MessageSource source) {
+		return new MessageSourceAccessor(source);
+	}
+
+	/**
+	 * Resolves the locale from users stored data if set and if not then from requests <code>Accept-Language</code>
+	 * header.
+	 */
+	class LocaleResolver extends AcceptHeaderLocaleResolver {
+
+		final List<Locale> LOCALES = List.of(
+				new Locale("en"),
+				new Locale("tr"));
+
+		@Override
+		public Locale resolveLocale(HttpServletRequest request) {
+			return getLocaleFromTrackedPerson().or(() -> resolveLocaleFrom(request)).orElse(Locale.GERMANY);
+		}
+
+		private Optional<Locale> getLocaleFromTrackedPerson() {
+
+			return accounts.getCurrentUser()
+					.flatMap(persons::findByAccount)
+					.map(TrackedPerson::getLocale)
+					.filter(it -> !Collections.disjoint(LocaleUtils.localeLookupList(it), LOCALES));
+		}
+
+		private Optional<Locale> resolveLocaleFrom(HttpServletRequest request) {
+
+			var headerLang = request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
+
+			return Optional.ofNullable(headerLang)
+					.filter(StringUtils::hasText)
+					.map(LanguageRange::parse)
+					.map(it -> Locale.lookup(it, LOCALES));
+		}
+	}
+
+	/**
+	 * Sets the used language to the response header <code>Content-Language</code>.
+	 */
+	@Component
+	@RequiredArgsConstructor
+	public class FirstFilter extends OncePerRequestFilter {
+
+		private final @NonNull LocaleResolver localeResolver;
+
+		@Override
+		protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+				FilterChain filterChain) throws ServletException, IOException {
+
+			filterChain.doFilter(httpServletRequest, httpServletResponse);
+
+			var locale = localeResolver.resolveLocale(httpServletRequest);
+			httpServletResponse.setLocale(locale);
+			httpServletResponse.addHeader(HttpHeaders.CONTENT_LANGUAGE, locale.toLanguageTag());
+		}
+	}
+}

--- a/backend/src/main/java/quarano/core/conversion/package-info.java
+++ b/backend/src/main/java/quarano/core/conversion/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.moduliths.NamedInterface("conversion")
+package quarano.core.conversion;

--- a/backend/src/main/java/quarano/department/RegistrationDetails.java
+++ b/backend/src/main/java/quarano/department/RegistrationDetails.java
@@ -13,6 +13,7 @@ import quarano.tracking.TrackedPerson;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
 import java.time.LocalDate;
+import java.util.Locale;
 import java.util.UUID;
 
 @Data
@@ -28,6 +29,7 @@ public class RegistrationDetails {
 	private UUID activationCodeLiteral;
 	private TrackedPersonIdentifier trackedPersonId;
 	private DepartmentIdentifier departmentId;
+	private Locale locale;
 
 	public Try<RegistrationDetails> apply(TrackedPerson person) {
 

--- a/backend/src/main/java/quarano/department/TrackedCaseEmail.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEmail.java
@@ -14,6 +14,6 @@ class TrackedCaseEmail extends AbstractTemplatedEmail {
 
 		super(DepartmentSender.of(trackedCase.getDepartment(), trackedCase.getType().toContactType()),
 				TrackedPersonReceipient.of(trackedCase.getTrackedPerson()),
-				subject, template, placeholders);
+				subject, template, placeholders, trackedCase.getTrackedPerson().getLocale());
 	}
 }

--- a/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
@@ -93,7 +93,7 @@ class TrackedCaseEventListener {
 
 			var trackedPerson = trackedCase.getTrackedPerson();
 			var subject = messages.getMessage("NewContactCaseMail.subject",
-					new Object[] { trackedCase.getDepartment().getName() });
+					new Object[] { trackedCase.getDepartment().getName() }, trackedPerson.getLocale());
 			var logArgs = new Object[] { trackedPerson.getFullName(), String.valueOf(trackedPerson.getEmailAddress()),
 					trackedCase.getId().toString() };
 

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -23,6 +23,8 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -100,6 +102,8 @@ public class RegistrationController {
 	private HttpEntity<?> doRegisterClient(RegistrationDto payload, MappedErrors errors) {
 
 		return registration.createTrackedPersonAccount(representations.from(payload))
+				.peek(it -> SecurityContextHolder.getContext()
+						.setAuthentication(new PreAuthenticatedAuthenticationToken(it, null)))
 				.<HttpEntity<?>> map(accountRepresentations::toTokenResponse)
 				.recover(RegistrationException.class, it -> recover(it, errors))
 				.recover(ActivationCodeException.class, it -> recover(it, errors))

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -17,8 +17,10 @@ import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 import quarano.department.activation.ActivationCodeException;
 import quarano.department.activation.ActivationCodeService;
 
+import java.util.Locale;
 import java.util.UUID;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpEntity;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,11 +48,14 @@ public class RegistrationController {
 	private final @NonNull RegistrationRepresentations representations;
 
 	@PostMapping("/api/registration")
-	public HttpEntity<?> registerClient(@Valid @RequestBody RegistrationDto payload, Errors errors) {
+	public HttpEntity<?> registerClient(@Valid @RequestBody RegistrationDto payload, Errors errors,
+			HttpServletRequest request) {
+
+		var locale = new AcceptHeaderLocaleResolver().resolveLocale(request);
 
 		return MappedPayloads.of(payload, errors)
 				.alwaysMap(RegistrationDto::validate)
-				.concludeSelfIfValid(this::doRegisterClient);
+				.concludeSelfIfValid((p, e) -> doRegisterClient(p, e, locale));
 	}
 
 	@PutMapping("/api/hd/cases/{id}/registration")
@@ -99,9 +105,9 @@ public class RegistrationController {
 		return ResponseEntity.ok(registration.isUsernameAvailable(userName));
 	}
 
-	private HttpEntity<?> doRegisterClient(RegistrationDto payload, MappedErrors errors) {
+	private HttpEntity<?> doRegisterClient(RegistrationDto payload, MappedErrors errors, Locale locale) {
 
-		return registration.createTrackedPersonAccount(representations.from(payload))
+		return registration.createTrackedPersonAccount(representations.from(payload).setLocale(locale))
 				.peek(it -> SecurityContextHolder.getContext()
 						.setAuthentication(new PreAuthenticatedAuthenticationToken(it, null)))
 				.<HttpEntity<?>> map(accountRepresentations::toTokenResponse)

--- a/backend/src/main/java/quarano/department/web/RegistrationRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationRepresentations.java
@@ -4,8 +4,8 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 
 import lombok.RequiredArgsConstructor;
 import quarano.core.CoreProperties;
-import quarano.core.EmailTemplates.Keys;
 import quarano.core.EmailTemplates;
+import quarano.core.EmailTemplates.Keys;
 import quarano.core.web.MapperWrapper;
 import quarano.department.RegistrationDetails;
 import quarano.department.TrackedCase;
@@ -61,7 +61,7 @@ class RegistrationRepresentations {
 
 		var key = trackedCase.isIndexCase() ? Keys.REGISTRATION_INDEX : Keys.REGISTRATION_CONTACT;
 
-		return templates.expandTemplate(key, placeholders);
+		return templates.expandTemplate(key, placeholders, trackedCase.getTrackedPerson().getLocale());
 	}
 
 	RepresentationModel<?> toNoRegistration(TrackedCase trackedCase) {

--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -327,6 +328,7 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 		private @Email String email;
 		private @Past LocalDate dateOfBirth;
 		private @Getter boolean infected;
+		private Locale locale;
 
 		Errors validate(Errors errors, CaseType type) {
 

--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -74,6 +74,7 @@ import org.springframework.validation.annotation.Validated;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.google.common.base.Objects;
 
 /**
  * @author Oliver Drotbohm
@@ -255,6 +256,11 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 
 		if (existing.isEnrollmentCompleted()) {
 			validateAfterEnrollment(payload, errors);
+		}
+
+		if (existing.getTrackedPerson().getAccount().isPresent()
+				&& !Objects.equal(payload.getLocale(), existing.getTrackedPerson().getLocale())) {
+			errors.rejectValue("locale", "TrackedCase.localeCantChange");
 		}
 
 		return validate(payload, existing.getType(), errors);
@@ -483,7 +489,8 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 
 	@Data
 	static class CommentInput {
-		@Textual String comment;
+		@Textual
+		String comment;
 	}
 
 	static class ValidationGroups {

--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -258,6 +258,8 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 			validateAfterEnrollment(payload, errors);
 		}
 
+		// When an account has been created, the user's setting matter and only the user can change these setting.
+		// So the locale of the TrackedPerson of the processed case must remain unchanged if there is an account for this person.
 		if (existing.getTrackedPerson().getAccount().isPresent()
 				&& !Objects.equal(payload.getLocale(), existing.getTrackedPerson().getLocale())) {
 			errors.rejectValue("locale", "TrackedCase.localeCantChange");

--- a/backend/src/main/java/quarano/diary/DiaryEntryReminderMailJob.java
+++ b/backend/src/main/java/quarano/diary/DiaryEntryReminderMailJob.java
@@ -83,10 +83,11 @@ class DiaryEntryReminderMailJob {
 				.flatMap(it -> departments.findById(it.getDepartmentId()))
 				.ifPresent(it -> {
 
-					var subject = messages.getMessage("DiaryEntryReminderMail.subject");
+					var subject = messages.getMessage("DiaryEntryReminderMail.subject", trackedPerson.getLocale());
 					var textTemplate = Keys.DIARY_REMINDER;
 					var slotTranslated = messages.getMessage(EnumMessageSourceResolvable.of(slot.getTimeOfDay()).getCodes()[0],
-							new Object[] { slot.getDate().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)) });
+							new Object[] { slot.getDate().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)) },
+							trackedPerson.getLocale());
 					var logArgs = new Object[] { trackedPerson.getFullName(), String.valueOf(trackedPerson.getEmailAddress()),
 							trackedPerson.getId().toString() };
 

--- a/backend/src/main/java/quarano/security/web/AuthenticationController.java
+++ b/backend/src/main/java/quarano/security/web/AuthenticationController.java
@@ -21,6 +21,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,6 +47,10 @@ class AuthenticationController {
 				.filter(it -> accounts.matches(password, it.getPassword()),
 						() -> new AccessDeniedException("Authentication failed!"))
 				.filter(this::hasOpenCaseForAccount, () -> new AccessDeniedException("Case already closed!"))
+				// set authentication to security context for a later use during the request (e.g. to get the current
+				// authentication)
+				.peek(it -> SecurityContextHolder.getContext()
+						.setAuthentication(new PreAuthenticatedAuthenticationToken(it, null)))
 				.<HttpEntity<?>> map(accountRepresentations::toTokenResponse)
 				.recover(EmptyResultDataAccessException.class, it -> toUnauthorized(it.getMessage()))
 				.get();

--- a/backend/src/main/java/quarano/security/web/QuaranoWebSecurityConfigurerAdapter.java
+++ b/backend/src/main/java/quarano/security/web/QuaranoWebSecurityConfigurerAdapter.java
@@ -66,6 +66,7 @@ public class QuaranoWebSecurityConfigurerAdapter extends WebSecurityConfigurerAd
 		httpSecurity.authorizeRequests(it -> {
 			it.mvcMatchers(SWAGGER_UI_WHITELIST).permitAll();
 			it.mvcMatchers("/docs/**").permitAll();
+			it.mvcMatchers("/h2_console/**").permitAll();
 			it.mvcMatchers("/login").permitAll();
 			it.mvcMatchers("/api/hd/accounts/**").access("hasRole('" + RoleType.ROLE_HD_ADMIN + "')");
 			it.mvcMatchers("/api/hd/**").access(hasAnyRole(RoleType.ROLE_HD_CASE_AGENT, RoleType.ROLE_HD_ADMIN));
@@ -77,6 +78,10 @@ public class QuaranoWebSecurityConfigurerAdapter extends WebSecurityConfigurerAd
 			it.mvcMatchers("/api/symptoms").authenticated();
 			it.mvcMatchers("/api/**").access("hasRole('" + RoleType.ROLE_USER + "')");
 		});
+		// this will ignore only h2-console csrf, spring security 4+
+		httpSecurity.csrf().ignoringAntMatchers("/h2-console/**");
+		//this will allow frames with same origin which is much more safe
+		httpSecurity.headers().frameOptions().sameOrigin();
 
 		httpSecurity.csrf().disable().cors(it -> {
 			it.configurationSource(corsConfigurationSource());

--- a/backend/src/main/java/quarano/tracking/TrackedPerson.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPerson.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -57,6 +58,8 @@ public class TrackedPerson extends QuaranoAggregate<TrackedPerson, TrackedPerson
 	private @Getter @Setter PhoneNumber mobilePhoneNumber;
 	private @Getter @Setter Address address = new Address();
 	private @Getter @Setter LocalDate dateOfBirth;
+
+	private @Getter(onMethod = @__(@Nullable)) @Setter(onMethod = @__(@Nullable)) Locale locale;
 
 	@OneToOne
 	@JoinColumn(name = "account_id")

--- a/backend/src/main/java/quarano/tracking/TrackedPersonDataInitializer.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPersonDataInitializer.java
@@ -10,6 +10,7 @@ import quarano.tracking.Address.HouseNumber;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
 import java.time.LocalDate;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.springframework.core.annotation.Order;
@@ -87,7 +88,8 @@ public class TrackedPersonDataInitializer implements DataInitializer {
 	 */
 	public static TrackedPerson createMarkus() {
 		return new TrackedPerson(VALID_TRACKED_PERSON2_ID_DEP1, "Markus", "Hanser",
-				EmailAddress.of("markus.hanser@testtest.de"), PhoneNumber.of("0621222255"), LocalDate.of(1990, 1, 1));
+				EmailAddress.of("markus.hanser@testtest.de"), PhoneNumber.of("0621222255"), LocalDate.of(1990, 1, 1))
+						.setLocale(Locale.UK);
 	}
 
 	/**
@@ -106,7 +108,7 @@ public class TrackedPersonDataInitializer implements DataInitializer {
 
 		return new TrackedPerson(VALID_TRACKED_PERSON4_ID_DEP2, "Jessica", "Wagner",
 				EmailAddress.of("jessica.wagner@testtest.de"), PhoneNumber.of("0621222256"), LocalDate.of(1989, 1, 1))
-				.setAddress(new Address("Wingertstraße", HouseNumber.of("70"), "Mannheim", ZipCode.of("68199")));
+						.setAddress(new Address("Wingertstraße", HouseNumber.of("70"), "Mannheim", ZipCode.of("68199")));
 	}
 
 	/**
@@ -138,7 +140,7 @@ public class TrackedPersonDataInitializer implements DataInitializer {
 	 */
 	public static TrackedPerson createHarry() {
 		return new TrackedPerson(VALID_TRACKED_PERSON6_ID_DEP1, "Harry", "Hirsch", EmailAddress.of("harry@hirsch.de"),
-				PhoneNumber.of("0621 115545"), null);
+				PhoneNumber.of("0621 115545"), null).setLocale(Locale.US);
 	}
 
 	/**

--- a/backend/src/main/java/quarano/tracking/TrackedPersonDataInitializer.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPersonDataInitializer.java
@@ -78,7 +78,8 @@ public class TrackedPersonDataInitializer implements DataInitializer {
 
 		return new TrackedPerson(VALID_TRACKED_PERSON1_ID_DEP1, "Tanja", "Mueller",
 				EmailAddress.of("tanja.mueller@testtest.de"), PhoneNumber.of("0621111155"), LocalDate.of(1975, 8, 3))
-						.setAddress(new Address("Hauptstr. 4", HouseNumber.of("3"), "Mannheim", ZipCode.of("68259")));
+						.setAddress(new Address("Hauptstr. 4", HouseNumber.of("3"), "Mannheim", ZipCode.of("68259")))
+						.setLocale(Locale.GERMANY);
 	}
 
 	/**

--- a/backend/src/main/java/quarano/tracking/TrackedPersonEmail.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPersonEmail.java
@@ -14,6 +14,6 @@ public class TrackedPersonEmail extends AbstractTemplatedEmail {
 			String subject, Key templateKey, Map<String, ? extends Object> placeholders) {
 
 		super(DepartmentSender.of(department, contactType), TrackedPersonReceipient.of(trackedPerson), subject, templateKey,
-				placeholders);
+				placeholders, trackedPerson.getLocale());
 	}
 }

--- a/backend/src/main/java/quarano/tracking/web/TrackedPersonDto.java
+++ b/backend/src/main/java/quarano/tracking/web/TrackedPersonDto.java
@@ -12,6 +12,7 @@ import quarano.tracking.ZipCode;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -43,4 +44,5 @@ public class TrackedPersonDto {
 	private @NotEmpty @Email String email;
 	private @NotNull @Past LocalDate dateOfBirth;
 	private List<URI> originContacts;
+	private Locale locale;
 }

--- a/backend/src/main/java/quarano/user/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/user/LocaleConfiguration.java
@@ -61,9 +61,13 @@ public class LocaleConfiguration {
 	 */
 	class LocaleResolver extends AcceptHeaderLocaleResolver {
 
+		public LocaleResolver() {
+			setDefaultLocale(Locale.GERMANY);
+		}
+
 		@Override
 		public Locale resolveLocale(HttpServletRequest request) {
-			return getLocaleFromTrackedPerson().or(() -> resolveLocaleFrom(request)).orElse(Locale.GERMANY);
+			return getLocaleFromTrackedPerson().or(() -> resolveLocaleFrom(request)).orElse(getDefaultLocale());
 		}
 
 		private Optional<Locale> getLocaleFromTrackedPerson() {

--- a/backend/src/main/java/quarano/user/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/user/LocaleConfiguration.java
@@ -1,4 +1,4 @@
-package quarano.core;
+package quarano.user;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -90,7 +90,7 @@ public class LocaleConfiguration {
 	 */
 	@Component
 	@RequiredArgsConstructor
-	public class FirstFilter extends OncePerRequestFilter {
+	public class SetContentHeaderFilter extends OncePerRequestFilter {
 
 		private final @NonNull LocaleResolver localeResolver;
 

--- a/backend/src/main/java/quarano/user/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/user/LocaleConfiguration.java
@@ -39,7 +39,8 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 public class LocaleConfiguration {
 
 	public static final List<Locale> LOCALES = List.of(
-			new Locale("en"),
+			Locale.GERMAN,
+			Locale.ENGLISH,
 			new Locale("tr"));
 
 	private final @NonNull AuthenticationManager accounts;

--- a/backend/src/main/java/quarano/user/LocaleConfiguration.java
+++ b/backend/src/main/java/quarano/user/LocaleConfiguration.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Locale.LanguageRange;
 import java.util.Optional;
 
 import javax.servlet.FilterChain;
@@ -25,9 +24,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 
 /**
  * Configuration class for locale and message related matters.
@@ -36,7 +37,7 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
  */
 @Configuration(proxyBeanMethods = false)
 @RequiredArgsConstructor
-public class LocaleConfiguration {
+public class LocaleConfiguration implements WebMvcConfigurer {
 
 	public static final List<Locale> LOCALES = List.of(
 			Locale.GERMAN,
@@ -44,7 +45,7 @@ public class LocaleConfiguration {
 			new Locale("tr"));
 
 	private final @NonNull AuthenticationManager accounts;
-	private final @NonNull TrackedPersonRepository persons;
+	private final @NonNull TrackedPersonRepository people;
 
 	@Bean
 	LocaleResolver localeResolver() {
@@ -56,6 +57,16 @@ public class LocaleConfiguration {
 		return new MessageSourceAccessor(source);
 	}
 
+	@Bean
+	LocaleChangeInterceptor localeChangeInterceptor() {
+		return new LocaleChangeInterceptor();
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry interceptorRegistry) {
+		interceptorRegistry.addInterceptor(localeChangeInterceptor());
+	}
+
 	/**
 	 * Resolves the locale from users stored data if set and if not then from requests <code>Accept-Language</code>
 	 * header.
@@ -64,29 +75,33 @@ public class LocaleConfiguration {
 
 		public LocaleResolver() {
 			setDefaultLocale(Locale.GERMANY);
+			setSupportedLocales(LOCALES);
 		}
 
 		@Override
 		public Locale resolveLocale(HttpServletRequest request) {
-			return getLocaleFromTrackedPerson().or(() -> resolveLocaleFrom(request)).orElse(getDefaultLocale());
+			return getLocaleFromTrackedPerson().orElseGet(() -> super.resolveLocale(request));
 		}
 
 		private Optional<Locale> getLocaleFromTrackedPerson() {
 
 			return accounts.getCurrentUser()
-					.flatMap(persons::findByAccount)
+					.flatMap(people::findByAccount)
 					.map(TrackedPerson::getLocale)
 					.filter(it -> !Collections.disjoint(LocaleUtils.localeLookupList(it), LOCALES));
 		}
 
-		private Optional<Locale> resolveLocaleFrom(HttpServletRequest request) {
-
-			var headerLang = request.getHeader(HttpHeaders.ACCEPT_LANGUAGE);
-
-			return Optional.ofNullable(headerLang)
-					.filter(StringUtils::hasText)
-					.map(LanguageRange::parse)
-					.map(it -> Locale.lookup(it, LOCALES));
+		/**
+		 * This method is called by {@link LocaleChangeInterceptor} to set the locale if one was specified by parameter.
+		 * Sets the given {@link Locale} to the {@link TrackedPerson} of the current account and saves this
+		 * {@link TrackedPerson}.
+		 */
+		@Override
+		public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
+			accounts.getCurrentUser()
+					.flatMap(people::findByAccount)
+					.map(it -> it.setLocale(locale))
+					.ifPresent(people::save);
 		}
 	}
 
@@ -95,7 +110,7 @@ public class LocaleConfiguration {
 	 */
 	@Component
 	@RequiredArgsConstructor
-	public class SetContentHeaderFilter extends OncePerRequestFilter {
+	class SetContentHeaderFilter extends OncePerRequestFilter {
 
 		private final @NonNull LocaleResolver localeResolver;
 

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -4,7 +4,6 @@ import static org.springframework.web.servlet.mvc.method.annotation.MvcUriCompon
 import static quarano.actions.web.AnomaliesLinkRelations.*;
 import static quarano.department.web.TrackedCaseLinkRelations.*;
 
-import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -23,8 +22,6 @@ import quarano.department.TrackedCaseRepository;
 import quarano.department.web.TrackedCaseController;
 import quarano.tracking.TrackedPersonRepository;
 
-import java.util.Locale;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
@@ -34,7 +31,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -112,48 +108,26 @@ public class UserController {
 				.onValidGet(() -> ResponseEntity.noContent().build());
 	}
 
-	@PatchMapping("/me/locale")
-	public HttpEntity<?> patchLocale(@Valid @RequestBody NewLocale payload, Errors errors, @LoggedIn Account account) {
-
-		return MappedPayloads.of(payload, errors)
-				.map(NewLocale::getLocale)
-				.peek(it -> trackedPersonRepository.findByAccount(account)
-						.map(a -> a.setLocale(it))
-						.ifPresent(a -> trackedPersonRepository.save(a)))
-				.onValidGet(() -> ResponseEntity.noContent().build());
-	}
-
-	@Data // Jackson can't simply call single argument constructors like by NewPassword - @Value don't work.
-	static class NewLocale {
-
-		/**
-		 * The current password.
-		 */
-		@NotBlank
-		String newLocale;
-
-		public Locale getLocale() {
-			return Locale.forLanguageTag(newLocale);
-		}
-	}
-
 	@Value
 	static class NewPassword {
 
 		/**
 		 * The current password.
 		 */
-		@NotBlank String current;
+		@NotBlank
+		String current;
 
 		/**
 		 * The new password to set.
 		 */
-		@NotBlank String password;
+		@NotBlank
+		String password;
 
 		/**
 		 * The new password repeated for verification.
 		 */
-		@NotBlank String passwordConfirm;
+		@NotBlank
+		String passwordConfirm;
 
 		NewPassword validate(Errors errors, EncryptedPassword existing, AccountService accounts) {
 

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -22,15 +22,12 @@ import quarano.department.TrackedCase;
 import quarano.department.TrackedCaseRepository;
 import quarano.department.web.TrackedCaseController;
 import quarano.tracking.TrackedPersonRepository;
-import quarano.user.LocaleConfiguration;
 
-import java.util.Collections;
 import java.util.Locale;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
-import org.apache.commons.lang3.LocaleUtils;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.server.mvc.MvcLink;
 import org.springframework.http.HttpEntity;
@@ -119,7 +116,6 @@ public class UserController {
 	public HttpEntity<?> patchLocale(@Valid @RequestBody NewLocale payload, Errors errors, @LoggedIn Account account) {
 
 		return MappedPayloads.of(payload, errors)
-				.alwaysMap(NewLocale::validate)
 				.map(NewLocale::getLocale)
 				.peek(it -> trackedPersonRepository.findByAccount(account)
 						.map(a -> a.setLocale(it))
@@ -135,15 +131,6 @@ public class UserController {
 		 */
 		@NotBlank
 		String newLocale;
-
-		NewLocale validate(Errors errors) {
-
-			if (Collections.disjoint(LocaleUtils.localeLookupList(getLocale()), LocaleConfiguration.LOCALES)) {
-				errors.rejectValue("newLocale", "Unsupported");
-			}
-
-			return this;
-		}
 
 		public Locale getLocale() {
 			return Locale.forLanguageTag(newLocale);

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -15,7 +15,6 @@ import quarano.account.DepartmentRepository;
 import quarano.account.Password.EncryptedPassword;
 import quarano.account.Password.UnencryptedPassword;
 import quarano.actions.web.AnomaliesController;
-import quarano.core.LocaleConfiguration;
 import quarano.core.web.LoggedIn;
 import quarano.core.web.MappedPayloads;
 import quarano.department.CaseType;
@@ -23,6 +22,7 @@ import quarano.department.TrackedCase;
 import quarano.department.TrackedCaseRepository;
 import quarano.department.web.TrackedCaseController;
 import quarano.tracking.TrackedPersonRepository;
+import quarano.user.LocaleConfiguration;
 
 import java.util.Collections;
 import java.util.Locale;

--- a/backend/src/main/resources/application-integrationtest.properties
+++ b/backend/src/main/resources/application-integrationtest.properties
@@ -1,7 +1,7 @@
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.datasource.generate-unique-name=true
-
+spring.h2.console.enabled=true
 quarano.diary.edit-tolerance=2m
 
 spring.jackson.serialization.indent-output=true

--- a/backend/src/main/resources/db/migration/V1008__Add_locale_of_person.sql
+++ b/backend/src/main/resources/db/migration/V1008__Add_locale_of_person.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracked_people ADD locale varchar(20) NULL;

--- a/backend/src/main/resources/masterdata/templates/en/diary-reminder.txt
+++ b/backend/src/main/resources/masterdata/templates/en/diary-reminder.txt
@@ -1,0 +1,18 @@
+Dear Mrs./Mr. {lastName},
+
+
+bitte denken Sie an Ihren regelmäßigen Tagebucheintrag in der Quarano-Anwendung.
+Uns fehlt noch der {slot}.
+
+https://{host}
+
+Bei allgemeinen Fragen zum Thema Corona wenden Sie sich bitte an die Corona-
+Hotline der Stadt Mannheim unter der Telefonnummer 
+0621-293 2253.
+
+• Montag bis Freitag von 9:00 – 17:00 Uhr
+• Samstags sowie an Sonn- und Feiertagen von 9:00 – 14:00 Uhr 
+
+Wir bedanken uns für Ihre Mitarbeit.
+
+Ihr Gesundheitsamt Mannheim

--- a/backend/src/main/resources/masterdata/templates/en/new-contact-case.txt
+++ b/backend/src/main/resources/masterdata/templates/en/new-contact-case.txt
@@ -1,0 +1,49 @@
+Dear Mrs./Mr. {lastName},
+
+
+Sie wurden von einem bestätigten COVID-19 Fall als Kontaktperson angegeben. Mit 
+dieser Mail möchten wir Sie vorab informieren, dass das Gesundheitsamt Mannheim 
+Kontakt zu Ihnen aufnehmen wird.
+
+Bitte melden Sie sich in der Zwischenzeit umgehend in unserer Online-Anwendung 
+zur Erfassung der Kontakte und Symptome an unter:
+
+https://{host}/client/enrollment/landing/contact/{activationCode}
+
+Bitte erfassen Sie dort Ihre Stammdaten und tragen Sie mögliche Kontaktpersonen 
+ein. Zudem bitten wir Sie, täglich zweimal Fieber zu messen sowie auftretende 
+Symptome (wie z.B. Atembeschwerden, Glieder- oder Muskelschmerzen, Durchfall) 
+direkt in das Online-Tool mit aufzunehmen.
+
+Das  weitere  Vorgehen  wird  ein  Mitarbeiter  des  Gesundheitsamtes  persönlich  mit 
+Ihnen per Telefon besprechen. Bis dahin bitten wir Sie um Folgendes: 
+
+• Bleiben Sie zu Hause und vermeiden Sie Kontakte zu anderen Personen.
+• Sie  und  andere  Personen  in  Ihrem  Haushalt  sollten  regelmäßig,  gründlich  und 
+mindestens 20 Sekunden lang die Hände mit Seife waschen. 
+• Die  Hände  sollten  aus  dem  Gesicht  ferngehalten  werden,  insbesondere  von  Mund, 
+Augen und Nase. 
+• Beachten  Sie  die  Husten-  und  Niesregeln:  Halten  Sie  beim  Husten  oder  Niesen 
+größtmöglichen  Abstand  zu  anderen  und  drehen  Sie  sich  dabei  am  besten  weg. 
+Niesen  oder  husten  Sie  in  die  Armbeuge  oder  in  ein  Einwegtaschentuch,  das  Sie 
+anschließend  entsorgen.  Waschen  Sie  danach  und  auch  nach  dem  Naseputzen 
+gründlich die Hände. 
+
+Bei allgemeinen Fragen zum Thema Corona wenden Sie sich bitte an die Corona-
+Hotline der Stadt Mannheim unter der Telefonnummer 
+0621-293 2253.
+
+• Montag bis Freitag von 9:00 – 17:00 Uhr
+• Samstags sowie an Sonn- und Feiertagen von 9:00 – 14:00 Uhr 
+
+Wir bedanken uns für Ihre Mitarbeit und werden in Kürze Kontakt mit Ihnen 
+aufnehmen.
+
+Ihr Gesundheitsamt Mannheim
+
+Wenn Sie akut ärztliche Behandlung benötigen, wenden Sie sich an Ihren Hausarzt/Ihre Hausärztin. 
+Nachts und am Wochenende stehen der hausärztliche Bereitschaftsdienst (116 117) oder in 
+schwerwiegenden Fällen die Notaufnahmen der Kliniken als Anlaufstelle zur Verfügung. In akuten 
+Notfällen zögern Sie bitte nicht, den Rettungsdienst unter der 112 zu rufen. Vor einer persönlichen 
+Vorstellung beim Arzt oder im Krankenhaus muss die telefonische Ankündigung mit Hinweis auf 
+COVID-19 erfolge

--- a/backend/src/main/resources/masterdata/templates/en/registration-contact.txt
+++ b/backend/src/main/resources/masterdata/templates/en/registration-contact.txt
@@ -1,0 +1,31 @@
+Dear Mrs./Mr. {lastName},
+
+
+Sie wurden vom Gesundheitsamt Mannheim kontaktiert und als enge Kontaktperson zu einem bestätigten Covid-19 Fall eingestuft und es wurde eine Quarantäne angeordnet. 
+
+Wie mit Ihnen am Telefon besprochen, melden Sie sich bitte umgehend in unserer Online-Anwendung zur Erfassung der Kontakte und Symptome an unter:
+
+https://{host}/client/enrollment/landing/contact/{activationCode}
+
+Bitte erfassen Sie dort Ihre Stammdaten und tragen Sie mögliche Kontaktpersonen ein. Zudem bitten wir Sie, täglich zweimal Fieber zu messen sowie auftretende Symptome (wie z.B. Atembeschwerden, Glieder- oder Muskelschmerzen, Durchfall) direkt in das Online-Tool mit aufzunehmen.
+
+Bei Fragen scheuen Sie sich bitte nicht, uns zu kontaktieren. Bei allgemeinen Fragen zum Thema Corona wenden Sie sich bitte an die Corona-Hotline der Stadt Mannheim unter der Telefonnummer 0621-293 2253.
+
+•   Montag bis Freitag von 9:00 – 17:00 Uhr
+•   Samstags sowie an Sonn- und Feiertagen von 9:00 – 14:00 Uhr 
+
+Bei Fragen, die Sie als Kontaktperson im Speziellen betreffen, wenden Sie sich bitte an die Hotline für Kontaktpersonen unter der Telefonnummer: 0621 -293 2212.
+
+•   Montag bis Freitag von 8:30-13:30 Uhr
+•   Samstags sowie an Sonn- und Feiertagen von 10:00 – 14:00 Uhr 
+
+
+Im Anhang erhalten Sie außerdem Informationen und Unterlagen, die für Sie als Kontaktperson wichtig sind. 
+
+
+Wir bedanken uns für Ihre Mitarbeit und wünschen Ihnen alles Gute. 
+
+Ihr Gesundheitsamt Mannheim
+
+
+Wenn Sie akut ärztliche Behandlung benötigen, wenden Sie sich an Ihren Hausarzt/Ihre Hausärztin. Nachts und am Wochenende stehen der hausärztliche Bereitschaftsdienst (116 117) oder in schwerwiegenden Fällen die Notaufnahmen der Kliniken als Anlaufstelle zur Verfügung. In akuten Notfällen zögern Sie bitte nicht, den Rettungsdienst unter der 112 zu rufen. Vor einer persönlichen Vorstellung beim Arzt oder im Krankenhaus muss die telefonische Ankündigung mit Hinweis auf COVID-19 erfolgen und dass Sie aktuell unter Quarantäne stehen.

--- a/backend/src/main/resources/masterdata/templates/en/registration-index.txt
+++ b/backend/src/main/resources/masterdata/templates/en/registration-index.txt
@@ -1,0 +1,22 @@
+Dear Mrs./Mr. {lastName},
+
+wie Sie bereits wissen, befinden Sie sich bis einschließlich {quarantineEndDate} in Quarantäne.
+
+Wie mit Ihnen am Telefon besprochen, melden Sie sich bitte umgehend in unserer Online-Anwendung zur Erfassung der Kontaktpersonen und der Symptome an unter:
+
+https://{host}/client/enrollment/landing/index/{activationCode}
+
+Bitte erfassen Sie dort Ihre Stammdaten und tragen Sie mögliche Kontaktpersonen ein, so dass wir zu diesen Kontakt aufnehmen können. Zudem bitten wir Sie, täglich zweimal Fieber zu messen sowie auftretende Symptome (wie z.B. Atembeschwerden, Glieder- oder Muskelschmerzen, Durchfall) direkt in das Online-Tool mit aufzunehmen.
+
+Bei allgemeinen Fragen zum Thema Corona wenden Sie sich bitte an die Corona-Hotline der Stadt Mannheim unter der Telefonnummer 0621-293 2253. 
+
+•   Montag bis Freitag von 9:00 – 17:00 Uhr
+•   Samstags sowie an Sonn- und Feiertagen von 9:00 – 14:00 Uhr 
+
+Auch die Internetseite der Stadt Mannheim (www.mannheim.de) bietet eine Vielzahl von Informationen an.
+
+
+Wenn Sie akut ärztliche Behandlung benötigen, wenden Sie sich an Ihren Hausarzt/Ihre Hausärztin. Nachts und am Wochenende stehen der hausärztliche Bereitschaftsdienst (116 117) oder in schwerwiegenden Fällen die Notaufnahmen der Kliniken als Anlaufstelle zur Verfügung. In akuten Notfällen zögern Sie bitte nicht, den Rettungsdienst unter der 112 zu rufen. Vor einer persönlichen Vorstellung beim Arzt oder im Krankenhaus muss die telefonische Ankündigung mit Hinweis auf COVID-19 erfolgen und dass Sie aktuell unter Quarantäne stehen.
+
+
+Mit freundlichen Grüßen,

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -106,6 +106,9 @@ quarano.actions.DescriptionCode.quarantine-ending=Quarantäneende prüfen.
 # Change password
 Invalid.newPassword.current=Ungültiges aktuelles Passwort!
 
+# Change locale
+Unsupported.newLocale.locale=Sprache wird nicht unterstützt!
+
 # Diary
 quarano.diary.Slot.TimeOfDay.1.morning=Morgen des {0}
 quarano.diary.Slot.TimeOfDay.2.evening=Abend des {0}

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -106,9 +106,6 @@ quarano.actions.DescriptionCode.quarantine-ending=Quarantäneende prüfen.
 # Change password
 Invalid.newPassword.current=Ungültiges aktuelles Passwort!
 
-# Change locale
-Unsupported.newLocale.locale=Sprache wird nicht unterstützt!
-
 # Diary
 quarano.diary.Slot.TimeOfDay.1.morning=Morgen des {0}
 quarano.diary.Slot.TimeOfDay.2.evening=Abend des {0}

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -71,6 +71,7 @@ PhoneOrMobile.mobilePhone=Bitte geben Sie eine gültige Telefonnummer an! Diese 
 PhoneOrMobile.phone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
 ContactCase.infected=Ein Kontaktfall darf nicht infiziert sein.
 EndBeforeStart.quarantineEndDate=Bitte geben Sie ein Enddatum ein, welches nach dem Startdatum liegt.
+TrackedCase.localeCantChange=Die Sprache kann nicht mehr geändert werden, wenn Sie vom Benutzer selber eingestellt wurde.
 
 quarano.department.CaseStatus.opened=angelegt
 quarano.department.CaseStatus.in-registration=in Registrierung

--- a/backend/src/main/resources/messages_de.properties
+++ b/backend/src/main/resources/messages_de.properties
@@ -1,0 +1,118 @@
+enrollment.detailsSubmissionRequired=Bitte geben Sie zuerst ihre persönlichen Daten ein!
+NotNull.IntialReportDto.hasPreExistingConditionsDescription=Bitte geben Sie Ihre relevanten Vorerkrankungen an!
+NotNull.IntialReportDto.belongToMedicalStaffDescription=Bitte geben Sie an in welcher Einrichtung Sie arbeiten!
+NotNull.IntialReportDto.hasContactToVulnerablePeopleDescription=Bitte beschreiben Sie kurz welche Art von Kontakt Sie zu Personen mit erhöhtem Risiko haben!
+
+# Stereotypes
+Alphabetic=Dieses Feld darf nur Buchstaben enthalten!
+AlphaNumeric=Dieses Feld darf nur Buchstaben und Zahlen enthalten!
+Textual=Dieses Feld darf nur Buchstaben, Zahlen, Satzzeichen und Zeilenumbrüche enthalten!
+UserName=Bitte geben Sie eine gültigen Benutzernamen ein! Dieser kann Buchstaben, Zahlen, - oder _ enthalten.
+Email=Bitte geben Sie eine gültige E-Mail-Adresse an!
+
+Pattern.city=Bitte geben Sie eine gültige Stadt an!
+Pattern.street=Bitte geben Sie eine gültige Straße an!
+Pattern.zipCode=Bitte geben Sie eine gültige Postleitzahl an!
+Pattern.mobilePhone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
+Pattern.phone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
+Pattern.email=Bitte geben Sie eine gültige E-Mail-Adresse an!
+Pattern.firstName=Bitte überprüfen Sie den eingegebenen Vornamen! Es sind nur Buchstaben, Leerzeichen und - erlaubt.
+Pattern.lastName=Bitte überprüfen Sie den eingegebenen Nachnamen! Es sind nur Buchstaben, Leerzeichen und - erlaubt.
+Pattern.houseNumber=Bitte geben Sie eine gültige Hausnummer an!
+Pattern.extReferenceNumber=Die eingegebene Vorgangsnummer enthält nicht erlaubte Zeichen. Vorgangsnummern dürfen nur aus Zahlen, Buchstaben und den folgenden Zeichen bestehen: -/_
+
+
+NotEmpty.city=Bitte geben Sie eine Stadt an!
+NotEmpty.firstName=Bitte geben Sie einen Vornamen an!
+NotEmpty.lastName=Bitte geben Sie einen Nachnamen an!
+NotEmpty.street=Bitte geben Sie eine Straße an!
+NotEmpty.zipCode=Bitte geben Sie eine Postleitzahl an!
+NotEmpty.email=Bitte geben Sie eine E-Mail-Addresse an!
+
+Past.dateOfBirth=Bitte geben Sie ein Geburtsdatum in der Vergangenheit an!
+NotNull.dateOfBirth=Bitte geben Sie ein Geburtsdatum in der Vergangenheit an!
+
+NotNull.dayOfFirstSymptoms=Bitte geben Sie ein Datum für die ersten Symptome an!
+
+Invalid.date=Bitte geben Sie ein korrektes Datum an!
+Invalid.contact=Ungültige Kontaktreferenz {0}!
+NotNull.contact=Bitte geben Sie eine Kontaktreferenz an!
+NotNull.date=Bitte geben Sie ein gültiges Datum an, das nicht in der Zukunft liegt!
+PastOrPresent.date=Bitte geben Sie ein gültiges Datum an, das nicht in der Zukunft liegt!
+
+Invalid.contactWays=Bitte geben Sie mindest einen Kontaktweg an (Telefon, Mobiltelefon, Email oder Identifikationshinweis)!
+
+# Account registration
+NonMatching.password=Bitte geben Sie übereinstimmende Passwörter ein!
+Invalid.accountRegistrationDto.clientCode=Ungültiger Aktivierungscode!
+Invalid.accountRegistrationDto.username=Ungültiger Benutzername!
+Invalid.accountRegistrationDto.birthDate=Ungültiger Geburtsdatum!
+Invalid.accountRegistration.wrongBirthDate=Bitte prüfen Sie Ihr Geburtsdatum! Das angegebene Datum stimmt nicht mit dem vom Gesundheitsamt hinterlegten Datum überein.
+Invalid.accountRegistration.username=Der eingegebene Benutzername ist nicht zulässig!
+
+#Roles
+quarano.account.RoleType.role-hd-admin=Admin
+quarano.account.RoleType.role-hd-case-agent=Fallbearbeiter
+quarano.account.RoleType.role-user=Bürger
+quarano.account.RoleType.role-quarano-admin=Quarano Admin
+
+# HD Account Validation
+quarano.account.web.NonMatching.password=Die eingegebenen Passwörter stimmen nicht überein.
+quarano.account.web.InvalidUserName=Der Username ist nicht gültig.
+quarano.account.web.UserNameNotAvailable=Der Username ist bereits vergeben.
+InvalidUserName=Der Username ist nicht gültig.
+UserNameNotAvailable=Der Username ist bereits vergeben.
+
+# TrackedCases
+NotNull.testDate=Bitte geben Sie ein gültiges Testdatum an!
+NotNull.quarantineStartDate=Bitte geben Sie ein gültiges Startdatum der Quarantäne an!
+NotNull.quarantineEndDate=Bitte geben Sie ein gültiges Enddatum der Quarantäne an!
+PhoneOrMobile.mobilePhone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
+PhoneOrMobile.phone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Zahlen, +, -, Klammern oder Leerzeichen enthalten.
+ContactCase.infected=Ein Kontaktfall darf nicht infiziert sein.
+EndBeforeStart.quarantineEndDate=Bitte geben Sie ein Enddatum ein, welches nach dem Startdatum liegt.
+
+quarano.department.CaseStatus.opened=angelegt
+quarano.department.CaseStatus.in-registration=in Registrierung
+quarano.department.CaseStatus.registration-completed=in Registrierung
+quarano.department.CaseStatus.tracking-active=in Nachverfolgung
+quarano.department.CaseStatus.stopped=abgeschlossen
+
+quarano.department.TrackedCase.Status.open=angelegt
+quarano.department.TrackedCase.Status.in-registration=in Registrierung
+quarano.department.TrackedCase.Status.registered=Registrierung abgeschlossen
+quarano.department.TrackedCase.Status.tracking=in Nachverfolgung
+quarano.department.TrackedCase.Status.concluded=abgeschlossen
+
+quarano.department.CaseType.index=Index
+quarano.department.CaseType.contact=Kontakt
+quarano.department.CaseType.contact-medical=Kontakt III
+quarano.department.CaseType.contact-vulnerable=Kontakt vul.
+
+quarano.department.TrackedCase.MailStatus.sent=versendet
+quarano.department.TrackedCase.MailStatus.cant-sent=konnte nicht versendet werden
+quarano.department.TrackedCase.MailStatus.not-sent=nicht versendet
+
+# Actions
+quarano.actions.DescriptionCode.first-characteristic-symptom=Erstes charakteristisches Symptom berichtet.
+quarano.actions.DescriptionCode.increased-temperature=Körpertemperatur {0} übersteigt Grenzwert {1}.
+quarano.actions.DescriptionCode.diary-entry-missing=Fehlender Tagebucheintrag vom {0}.
+quarano.actions.DescriptionCode.missing-details-index=Fehlende Stammdaten (INDEX).
+quarano.actions.DescriptionCode.missing-details-contact=Fehlende Stammdaten (KP).
+quarano.actions.DescriptionCode.initial-call-open-index=Initialer Anruf offen (INDEX).
+quarano.actions.DescriptionCode.initial-call-open-contact=Initialer Anruf offen (KP).
+quarano.actions.DescriptionCode.quarantine-ending=Quarantäneende prüfen.
+
+# Change password
+Invalid.newPassword.current=Ungültiges aktuelles Passwort!
+
+# Change locale
+Unsupported.newLocale.locale=Sprache wird nicht unterstützt!
+
+# Diary
+quarano.diary.Slot.TimeOfDay.1.morning=Morgen des {0}
+quarano.diary.Slot.TimeOfDay.2.evening=Abend des {0}
+
+# Mails
+NewContactCaseMail.subject=Information vom {0}
+DiaryEntryReminderMail.subject=Erinnerung an Covid-19 Symptomtagebuch

--- a/backend/src/main/resources/messages_en.properties
+++ b/backend/src/main/resources/messages_en.properties
@@ -72,17 +72,17 @@ PhoneOrMobile.phone=Bitte geben Sie eine gültige Telefonnummer an! Diese kann Z
 ContactCase.infected=Ein Kontaktfall darf nicht infiziert sein.
 EndBeforeStart.quarantineEndDate=Bitte geben Sie ein Enddatum ein, welches nach dem Startdatum liegt.
 
-quarano.department.CaseStatus.opened=angelegt
-quarano.department.CaseStatus.in-registration=in Registrierung
-quarano.department.CaseStatus.registration-completed=in Registrierung
-quarano.department.CaseStatus.tracking-active=in Nachverfolgung
-quarano.department.CaseStatus.stopped=abgeschlossen
+quarano.department.CaseStatus.opened=opend
+quarano.department.CaseStatus.in-registration=in registration
+quarano.department.CaseStatus.registration-completed=registration completed
+quarano.department.CaseStatus.tracking-active=tracking
+quarano.department.CaseStatus.stopped=stopped
 
-quarano.department.TrackedCase.Status.open=angelegt
-quarano.department.TrackedCase.Status.in-registration=in Registrierung
-quarano.department.TrackedCase.Status.registered=Registrierung abgeschlossen
-quarano.department.TrackedCase.Status.tracking=in Nachverfolgung
-quarano.department.TrackedCase.Status.concluded=abgeschlossen
+quarano.department.TrackedCase.Status.open=open
+quarano.department.TrackedCase.Status.in-registration=in registration
+quarano.department.TrackedCase.Status.registered=registered
+quarano.department.TrackedCase.Status.tracking=tracking
+quarano.department.TrackedCase.Status.concluded=concluded
 
 quarano.department.CaseType.index=Index
 quarano.department.CaseType.contact=Kontakt
@@ -104,7 +104,7 @@ quarano.actions.DescriptionCode.initial-call-open-contact=Initialer Anruf offen 
 quarano.actions.DescriptionCode.quarantine-ending=Quarantäneende prüfen.
 
 # Change password
-Invalid.newPassword.current=Ungültiges aktuelles Passwort!
+Invalid.newPassword.current=Invalid current password!
 
 # Diary
 quarano.diary.Slot.TimeOfDay.1.morning=Morgen des {0}

--- a/backend/src/test/java/quarano/core/LocaleConfigurationTests.java
+++ b/backend/src/test/java/quarano/core/LocaleConfigurationTests.java
@@ -1,0 +1,165 @@
+package quarano.core;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static quarano.core.web.QuaranoHttpHeaders.*;
+
+import lombok.RequiredArgsConstructor;
+import quarano.QuaranoWebIntegrationTest;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+
+@QuaranoWebIntegrationTest
+@RequiredArgsConstructor
+public class LocaleConfigurationTests {
+
+	static final String ME = "/api/user/me";
+
+	static final String DEFAULT_LOCALE = "de-DE";
+
+	final String USERNAME_WITH_LOCALE = "DemoAccount";
+	final String PASSWORD_WITH_LOCALE = "DemoPassword";
+	final String USERNAME_WITHOUT_LOCALE = "test3";
+	final String PASSWORD_WITHOUT_LOCALE = "test123";
+
+	final MockMvc mvc;
+	final ObjectMapper mapper;
+
+	@Test
+	void testLocaleHandlingWithDefault() throws Exception {
+
+		var response = login(USERNAME_WITHOUT_LOCALE, PASSWORD_WITHOUT_LOCALE, HttpHeaders.EMPTY);
+
+		assertThat(response.getHeader(CONTENT_LANGUAGE)).isEqualTo(DEFAULT_LOCALE);
+
+		var token = response.getHeader(AUTH_TOKEN);
+
+		var headers = new HttpHeaders();
+		headers.setAcceptLanguageAsLocales(List.of(Locale.KOREA)); // unsupported language
+
+		var responseGet = performGet(ME, token, headers);
+		var document = JsonPath.parse(responseGet.getContentAsString());
+
+		assertThat(responseGet.getHeader(CONTENT_LANGUAGE)).isEqualTo(DEFAULT_LOCALE);
+		assertThat(document.read("$.client.locale", String.class)).isNull();
+
+		var responsePut = performWrongPasswordChange(token, headers);
+		document = JsonPath.parse(responsePut.getContentAsString());
+
+		assertThat(responsePut.getHeader(CONTENT_LANGUAGE)).isEqualTo(DEFAULT_LOCALE);
+		assertThat(document.read("$.current", String.class)).isEqualTo("Ungültiges aktuelles Passwort!");
+	}
+
+	@Test
+	void testLocaleHandlingWithAcceptLanguageHeader() throws Exception {
+
+		var headers = new HttpHeaders();
+		headers.setAcceptLanguageAsLocales(List.of(Locale.forLanguageTag("tr")));
+
+		var response = login(USERNAME_WITHOUT_LOCALE, PASSWORD_WITHOUT_LOCALE, headers);
+
+		assertThat(response.getHeader(CONTENT_LANGUAGE)).isEqualTo("tr");
+
+		var token = response.getHeader(AUTH_TOKEN);
+
+		headers.setAcceptLanguageAsLocales(List.of(Locale.forLanguageTag("en")));
+
+		var responseGet = performGet(ME, token, headers);
+		var document = JsonPath.parse(responseGet.getContentAsString());
+
+		assertThat(responseGet.getHeader(CONTENT_LANGUAGE)).isEqualTo("en");
+		assertThat(document.read("$.client.locale", String.class)).isNull();
+
+		var responsePut = performWrongPasswordChange(token, headers);
+		document = JsonPath.parse(responsePut.getContentAsString());
+
+		assertThat(responsePut.getHeader(CONTENT_LANGUAGE)).isEqualTo("en");
+		assertThat(document.read("$.current", String.class)).isEqualTo("Invalid current password!");
+	}
+
+	@Test
+	void testLocaleHandlingWithUserSetting() throws Exception {
+
+		var response = login(USERNAME_WITH_LOCALE, PASSWORD_WITH_LOCALE, HttpHeaders.EMPTY);
+
+		assertThat(response.getHeader(CONTENT_LANGUAGE)).isEqualTo("en-GB");
+
+		var token = response.getHeader(AUTH_TOKEN);
+
+		var headers = new HttpHeaders();
+		headers.setAcceptLanguageAsLocales(List.of(Locale.forLanguageTag("tr")));
+
+		var responseGet = performGet(ME, token, headers);
+		var document = JsonPath.parse(responseGet.getContentAsString());
+
+		assertThat(responseGet.getHeader(CONTENT_LANGUAGE)).isEqualTo("en-GB");
+		assertThat(document.read("$.client.locale", String.class)).isEqualTo("en_GB");
+
+		var responsePut = performWrongPasswordChange(token, headers);
+		document = JsonPath.parse(responsePut.getContentAsString());
+
+		assertThat(responsePut.getHeader(CONTENT_LANGUAGE)).isEqualTo("en-GB");
+		assertThat(document.read("$.current", String.class)).isEqualTo("Invalid current password!");
+	}
+
+	private HttpServletResponse login(String username, String password, HttpHeaders headers) throws Exception {
+
+		return mvc.perform(post("/login")
+				.header("Origin", "*")
+				.headers(headers)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createRequestBody(username, password)))
+				.andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse();
+	}
+
+	private String createRequestBody(String username, String password) throws Exception {
+		return mapper.writeValueAsString(Map.of("username", username, "password", password));
+	}
+
+	private MockHttpServletResponse performGet(String urlTemplate, String token, HttpHeaders headers) throws Exception {
+
+		return mvc.perform(get(urlTemplate)
+				.header("Origin", "*")
+				.header("Authorization", "Bearer " + token)
+				.headers(headers)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON))
+				.andReturn().getResponse();
+	}
+
+	private MockHttpServletResponse performWrongPasswordChange(String token, HttpHeaders headers) throws Exception {
+
+		return mvc.perform(put("/api/user/me/password")
+				.header("Origin", "*")
+				.header("Authorization", "Bearer " + token)
+				.headers(headers)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(createRequestBody("xxxx#", "xxxx#", "xxxx#")))
+				.andExpect(status().is4xxClientError())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andReturn().getResponse();
+	}
+
+	private String createRequestBody(String current, String password, String passwordConfirm) throws Exception {
+		return mapper
+				.writeValueAsString(Map.of("current", current, "password", password, "passwordConfirm", passwordConfirm));
+	}
+}

--- a/backend/src/test/java/quarano/core/LocaleConfigurationTests.java
+++ b/backend/src/test/java/quarano/core/LocaleConfigurationTests.java
@@ -37,9 +37,7 @@ public class LocaleConfigurationTests {
 	static final String DEFAULT_LOCALE = "de-DE";
 
 	final String USERNAME_WITH_LOCALE = "DemoAccount";
-	final String PASSWORD_WITH_LOCALE = "DemoPassword";
 	final String USERNAME_WITHOUT_LOCALE = "test3";
-	final String PASSWORD_WITHOUT_LOCALE = "test123";
 
 	final MockMvc mvc;
 	final ObjectMapper mapper;
@@ -103,7 +101,7 @@ public class LocaleConfigurationTests {
 	@ValueSource(strings = { "de", "de_DE", "en", "en_GB", "tr", "tr_TR", "en_CA" })
 	void processCorrectLocalesSucceeds(String locale) throws Exception {
 
-		mvc.perform(get("/api/user/me")
+		mvc.perform(get(ME)
 				.header("Origin", "*")
 				.locale(Locale.forLanguageTag("tr"))
 				.param("locale", locale))
@@ -122,19 +120,14 @@ public class LocaleConfigurationTests {
 	void processInvalidLocalesRejects(String locale) throws Exception {
 
 		var exception = assertThrows(NestedServletException.class, () -> {
-			mvc.perform(post("/login")
+			mvc.perform(get(ME)
 					.header("Origin", "*")
 					.param("locale", locale)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(createRequestBody(USERNAME_WITHOUT_LOCALE, PASSWORD_WITHOUT_LOCALE)))
+					.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().is4xxClientError());
 		});
 
 		assertThat(exception.getCause()).isInstanceOf(IllegalArgumentException.class);
-	}
-
-	private String createRequestBody(String username, String password) throws Exception {
-		return mapper.writeValueAsString(Map.of("username", username, "password", password));
 	}
 
 	private MockHttpServletResponse performGet(String urlTemplate, Locale locale) throws Exception {

--- a/backend/src/test/java/quarano/department/MailForNewContactCaseEventListenerTests.java
+++ b/backend/src/test/java/quarano/department/MailForNewContactCaseEventListenerTests.java
@@ -78,7 +78,7 @@ class MailForNewContactCaseEventListenerTests {
 		Message message = greenMail.getReceivedMessages()[0];
 
 		assertThat(GreenMailUtil.getBody(message)).startsWith("Sehr geehrte/geehrter Frau/Herr Mueller,")
-				.doesNotContain("==========");
+				.doesNotContain("=3D".repeat(10)); // is ==========
 
 		greenMail.purgeEmailFromAllMailboxes();
 
@@ -108,7 +108,7 @@ class MailForNewContactCaseEventListenerTests {
 		message = greenMail.getReceivedMessages()[0];
 
 		assertThat(GreenMailUtil.getBody(message)).startsWith("Dear Mrs./Mr. Mueller,")
-				.contains("=3D".repeat(10)) // is ==========
+				.contains("\r\n\r\n" + "=3D".repeat(10) + "\r\n\r\n") // is ==========
 				.contains("Sehr geehrte/geehrter Frau/Herr Mueller,");
 	}
 

--- a/backend/src/test/java/quarano/department/web/RegistrationWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/RegistrationWebIntegrationTests.java
@@ -175,7 +175,7 @@ class RegistrationWebIntegrationTests {
 		var harry = harryCase.getTrackedPerson();
 
 		assertThat(document.read("$.email", String.class)).contains(harry.getLastName());
-		assertThat(document.read("$.email", String.class)).contains("==========");
+		assertThat(document.read("$.email", String.class)).contains("\r\n\r\n==========\r\n\r\n");
 		assertThat(document.read("$.email", String.class)).startsWith("Dear Mrs./Mr. " + harry.getLastName() + ",");
 		assertThat(document.read("$.expirationDate", String.class)).isNotBlank();
 		assertThat(document.read("$.activationCode", String.class)).isNotBlank();
@@ -203,7 +203,7 @@ class RegistrationWebIntegrationTests {
 		var document = JsonPath.parse(response);
 		var harry = harryCase.getTrackedPerson();
 
-		assertThat(document.read("$.email", String.class)).contains("==========");
+		assertThat(document.read("$.email", String.class)).contains("\r\n\r\n==========\r\n\r\n");
 		assertThat(document.read("$.email", String.class)).startsWith("Dear Mrs./Mr. " + harry.getLastName() + ",");
 		assertThat(document.read("$.email", String.class)).contains("Sehr geehrte/geehrter Frau/Herr");
 

--- a/backend/src/test/java/quarano/diary/DiaryEntryReminderMailJobTests.java
+++ b/backend/src/test/java/quarano/diary/DiaryEntryReminderMailJobTests.java
@@ -10,6 +10,7 @@ import javax.mail.Message;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.icegreen.greenmail.util.GreenMail;
@@ -21,6 +22,11 @@ class DiaryEntryReminderMailJobTests {
 
 	private final DiaryEntryReminderMailJob job;
 	private final GreenMail greenMail;
+
+	@BeforeEach
+	void resetGreenMail() throws Exception {
+		greenMail.purgeEmailFromAllMailboxes();
+	}
 
 	@Test // CORE-61
 	void runsCorrect() throws MessagingException {

--- a/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
@@ -11,7 +11,6 @@ import quarano.QuaranoWebIntegrationTest;
 import quarano.core.web.QuaranoHttpHeaders;
 import quarano.user.web.UserController.NewPassword;
 
-import java.util.Locale;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -180,31 +179,6 @@ class UserControllerWebIntegrationTests extends AbstractDocumentation {
 		issuePasswordChange(new NewPassword(PASSWORD, newPassword, newPassword))
 				.andDo(documentPasswordChange())
 				.andExpect(status().is2xxSuccessful());
-	}
-
-	@Test
-	void changesLocale() throws Exception {
-
-		var token = login(USERNAME, PASSWORD);
-
-		// before
-		var document = JsonPath.parse(performGet(token));
-
-		assertThat(document.read("$.client.locale", String.class)).isEqualTo("en_GB");
-
-		// change
-		var newLocale = new Locale("tr");
-
-		mvc.perform(patch("/api/user/me/locale")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(Map.of("newLocale", newLocale.toLanguageTag())))
-				.header("Authorization", "Bearer " + token))
-				.andExpect(status().is2xxSuccessful());
-
-		// after
-		document = JsonPath.parse(performGet(token));
-
-		assertThat(document.read("$.client.locale", String.class)).isEqualTo("tr");
 	}
 
 	private String login(String username, String password) throws Exception {


### PR DESCRIPTION
CORE-355 backend part of the language support

**CORE-373 and CORE-374 - determines the language to be used and adds Content-Language Header:**
- Extends `TrackedPerson` to handle the language of a user.
- The new `LocaleResolver` in `LocaleConfiguration` resolves the locale for the request.
    1. Locale of the user
    2. Locale from Accept-Language-Header of the request
    3. de-DE as default
- Adds `Content-Language` Header with the used Language to every response. This is done in a filter which is specified in the `LocaleConfiguration`.
- `LocaleConfiguration` collects all locale and message configuration.
- en and tr are supported at the moment.
- The login method of `AuthenticationController` sets an Authentication after an successfull login. This is necessary so that LocaleResolver can access the language of the current user at the end of the login request.


**CORE-372 - adds an endpoint to change the locale of the current user**
- At the moment the locale is only set in the TrackedPerson, if it is available. This should possibly be extended to the Account in a later step. But for this, some functional questions have to be clarified.
- Accepts only supported languages -> adds an error message.

 **CORE-375 - extends the email template handling by a locale**
- The file name is now resolved lazy to include the language.
- The schema for the language of templates is the folder hierarchy.
	```/<file> = fallback template
	/<language>/<file> = special language (e.g. en/ or de/)
	/<language>/<country>/<file> = special language and country (e.g. en/GB/ or de/DE/)
	/<language>/<country>/<variant>/<file> = special language, country and variant
	The most exact hit is selected!

**General**
- Adds files and data for tests, and various tests for the functions.