### PR TITLE
CORE-427 dont open unknown contact popup for existing contact

### DIFF
--- a/frontend/libs/shared/ui-multiple-autocomplete/src/lib/multiple-autocomplete/multiple-autocomplete.component.html
+++ b/frontend/libs/shared/ui-multiple-autocomplete/src/lib/multiple-autocomplete/multiple-autocomplete.component.html
@@ -23,7 +23,7 @@
           ? ('MULTIPLE_AUTOCOMPLETE.KEINE_WEITEREN_AUSWAHLMÖGLICHKEITEN' | translate)
           : null
       "
-      (blur)="checkInputForData()"
+      (blur)="checkInputForData($event)"
       #trigger="matAutocompleteTrigger"
     />
   </mat-chip-list>

--- a/frontend/libs/shared/ui-multiple-autocomplete/src/lib/multiple-autocomplete/multiple-autocomplete.component.ts
+++ b/frontend/libs/shared/ui-multiple-autocomplete/src/lib/multiple-autocomplete/multiple-autocomplete.component.ts
@@ -1,8 +1,8 @@
 import { FormControl } from '@angular/forms';
 import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { filter, startWith, takeUntil } from 'rxjs/operators';
-import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { IIdentifiable } from '@qro/shared/util-data-access';
 import { cloneDeep } from 'lodash';
@@ -24,7 +24,7 @@ export class MultipleAutocompleteComponent implements OnInit, OnDestroy {
   inputControl = new FormControl();
   separatorKeysCodes: number[] = [ENTER, COMMA];
   @ViewChild('input') input: ElementRef<HTMLInputElement>;
-  @ViewChild('auto') autocomplete;
+  @ViewChild('auto') autocomplete: MatAutocomplete;
   destroy$: Subject<void> = new Subject<void>();
   filteredList$$: BehaviorSubject<IIdentifiable[]> = new BehaviorSubject<IIdentifiable[]>(undefined);
 
@@ -70,7 +70,11 @@ export class MultipleAutocompleteComponent implements OnInit, OnDestroy {
     return arrayToReturn;
   }
 
-  checkInputForData() {
+  checkInputForData(event: FocusEvent) {
+    if (event.relatedTarget && this.autocomplete.panel?.nativeElement?.contains?.(event.relatedTarget)) {
+      // Do nothing if the user selected an option from the autocomplete list
+      return;
+    }
     const input = this.inputControl.value;
     const inList = this.isInputInSelectedList(input);
     if (!inList && input) {


### PR DESCRIPTION
Popup für unbekannten Kontakt unterdrücken, wenn der Benutzer einen Eintrag aus dem Autocomplete Liste auswählt und das Inputfeld ist nicht leer