### PR TITLE
CORE-474 Added i18n messages for ActivationCodeExceptions

### DIFF
--- a/backend/src/main/java/quarano/department/activation/ActivationCodeException.java
+++ b/backend/src/main/java/quarano/department/activation/ActivationCodeException.java
@@ -1,10 +1,12 @@
 package quarano.department.activation;
 
+import lombok.Getter;
 import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 
 /**
  * @author Oliver Drotbohm
  */
+@Getter
 public class ActivationCodeException extends RuntimeException {
 
 	private static final long serialVersionUID = -1862988574924745449L;
@@ -36,7 +38,7 @@ public class ActivationCodeException extends RuntimeException {
 		this.status = status;
 	}
 
-	enum Status {
+	public enum Status {
 		NOT_FOUND, EXPIRED, USED_OR_CANCELED;
 	}
 }

--- a/backend/src/main/java/quarano/department/activation/ActivationCodeException.java
+++ b/backend/src/main/java/quarano/department/activation/ActivationCodeException.java
@@ -9,36 +9,34 @@ import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 @Getter
 public class ActivationCodeException extends RuntimeException {
 
-	private static final long serialVersionUID = -1862988574924745449L;
+		private static final long serialVersionUID = -1862988574924745449L;
 
-	private final ActivationCodeIdentifier code;
-	private final Status status;
+		private final String messageKey;
 
-	public static ActivationCodeException notFound(ActivationCodeIdentifier id) {
-		return new ActivationCodeException(id, Status.NOT_FOUND, "Could not find activation code " + id.toString());
-	}
+		public static ActivationCodeException notFound(ActivationCodeIdentifier id) {
+				return new ActivationCodeException("Could not find activation code " + id.toString(),
+						"Invalid.accountRegistration.clientCodeNotFound");
+		}
 
-	public static ActivationCodeException expired(ActivationCode code) {
-		return new ActivationCodeException(code.getId(), Status.EXPIRED, "Activation code " + code.getId() + " expired!");
-	}
+		public static ActivationCodeException expired(ActivationCode code) {
+				return new ActivationCodeException("Activation code " + code.getId() + " expired!",
+						"Invalid.accountRegistration.clientCodeExpired");
+		}
 
-	public static ActivationCodeException usedOrCanceled(ActivationCode code) {
-		return new ActivationCodeException(code.getId(), Status.USED_OR_CANCELED,
-				"Activation code " + code.getId() + " was already used or canceled!");
-	}
+		public static ActivationCodeException usedOrCanceled(ActivationCode code) {
+				return new ActivationCodeException(
+						"Activation code " + code.getId() + " was already used or canceled!",
+						"Invalid.accountRegistration.clientCodeUsedOrCanceled");
+		}
 
-	public static ActivationCodeException activationConcluded() {
-		return new ActivationCodeException(null, Status.USED_OR_CANCELED, "Account was already activated!");
-	}
+		public static ActivationCodeException activationConcluded() {
+				return new ActivationCodeException("Account was already activated!",
+						"Invalid.accountRegistration.clientCodeUsedOrCanceled");
+		}
 
-	private ActivationCodeException(ActivationCodeIdentifier code, Status status, String message) {
+		private ActivationCodeException(String message, String messageKey) {
 
-		super(message);
-		this.code = code;
-		this.status = status;
-	}
-
-	public enum Status {
-		NOT_FOUND, EXPIRED, USED_OR_CANCELED;
-	}
+				super(message);
+				this.messageKey = messageKey;
+		}
 }

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -134,7 +134,7 @@ public class RegistrationController {
 				.toBadRequest();
 	}
 
-	private HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
+	private static HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
 		final var field = "clientCode";
 		return errors
 			.rejectField(it.getStatus().equals(Status.NOT_FOUND), field, "Invalid.accountRegistration.clientCodeNotFound")

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -15,6 +15,7 @@ import quarano.department.TrackedCase.TrackedCaseIdentifier;
 import quarano.department.TrackedCaseRepository;
 import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 import quarano.department.activation.ActivationCodeException;
+import quarano.department.activation.ActivationCodeException.Status;
 import quarano.department.activation.ActivationCodeService;
 
 import java.util.Locale;
@@ -133,7 +134,12 @@ public class RegistrationController {
 				.toBadRequest();
 	}
 
-	private static HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
-		return errors.rejectField("clientCode", "Invalid", it.getMessage()).toBadRequest();
+	private HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
+		final var field = "clientCode";
+		return errors
+			.rejectField(it.getStatus().equals(Status.NOT_FOUND), field, "Invalid.accountRegistration.clientCodeNotFound")
+			.rejectField(it.getStatus().equals(Status.EXPIRED), field, "Invalid.accountRegistration.clientCodeExpired")
+			.rejectField(it.getStatus().equals(Status.USED_OR_CANCELED), field, "Invalid.accountRegistration.clientCodeUsedOrCanceled")
+			.toBadRequest();
 	}
 }

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -15,7 +15,6 @@ import quarano.department.TrackedCase.TrackedCaseIdentifier;
 import quarano.department.TrackedCaseRepository;
 import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 import quarano.department.activation.ActivationCodeException;
-import quarano.department.activation.ActivationCodeException.Status;
 import quarano.department.activation.ActivationCodeService;
 
 import java.util.Locale;
@@ -135,11 +134,8 @@ public class RegistrationController {
 	}
 
 	private static HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
-		final var field = "clientCode";
 		return errors
-			.rejectField(it.getStatus().equals(Status.NOT_FOUND), field, "Invalid.accountRegistration.clientCodeNotFound")
-			.rejectField(it.getStatus().equals(Status.EXPIRED), field, "Invalid.accountRegistration.clientCodeExpired")
-			.rejectField(it.getStatus().equals(Status.USED_OR_CANCELED), field, "Invalid.accountRegistration.clientCodeUsedOrCanceled")
+			.rejectField("clientCode", it.getMessageKey())
 			.toBadRequest();
 	}
 }

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -49,6 +49,9 @@ Invalid.accountRegistrationDto.username=Ungültiger Benutzername!
 Invalid.accountRegistrationDto.birthDate=Ungültiger Geburtsdatum!
 Invalid.accountRegistration.wrongBirthDate=Bitte prüfen Sie Ihr Geburtsdatum! Das angegebene Datum stimmt nicht mit dem vom Gesundheitsamt hinterlegten Datum überein.
 Invalid.accountRegistration.username=Der eingegebene Benutzername ist nicht zulässig!
+Invalid.accountRegistration.clientCodeNotFound=Der von Ihnen eingegebene Anmeldecode ist falsch. Bitte überprüfen Sie, ob er genau dem Code entspricht, den Sie per E-Mail erhalten haben. Wenn nicht, melden Sie sich bitte umgehend telefonisch bei Ihrem Gesundheitsamt.
+Invalid.accountRegistration.clientCodeExpired=Der von Ihnen eingegebene Anmeldecode ist abgelaufen! Bitte kontaktieren sie das Gesundheitsamt um einen neuen Code zu bekommen. Dieser ist 24 Stunden gültig.
+Invalid.accountRegistration.clientCodeUsedOrCanceled=Der von Ihnen eingegebene Anmeldecode ist entweder nicht aktuell oder bereits benutzt worden. Bitte überprüfen Sie, ob Sie einen neueren Code vom Gesundheitsamt erhalten haben.
 
 #Roles
 quarano.account.RoleType.role-hd-admin=Admin

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -44,7 +44,6 @@ Invalid.contactWays=Bitte geben Sie mindest einen Kontaktweg an (Telefon, Mobilt
 
 # Account registration
 NonMatching.password=Bitte geben Sie übereinstimmende Passwörter ein!
-Invalid.accountRegistrationDto.clientCode=Ungültiger Aktivierungscode!
 Invalid.accountRegistrationDto.username=Ungültiger Benutzername!
 Invalid.accountRegistrationDto.birthDate=Ungültiger Geburtsdatum!
 Invalid.accountRegistration.wrongBirthDate=Bitte prüfen Sie Ihr Geburtsdatum! Das angegebene Datum stimmt nicht mit dem vom Gesundheitsamt hinterlegten Datum überein.

--- a/backend/src/main/resources/messages_en.properties
+++ b/backend/src/main/resources/messages_en.properties
@@ -44,7 +44,6 @@ Invalid.contactWays=Please enter at least one means of contact (Home or mobile t
 
 # Account registration
 NonMatching.password=Please enter an identical password!
-Invalid.accountRegistrationDto.clientCode=Invalid activation code!
 Invalid.accountRegistrationDto.username=Invalid user name!
 Invalid.accountRegistrationDto.birthDate=Invalid date of birth!
 Invalid.accountRegistration.wrongBirthDate=Please check the date of birth entered! The date entered does not correspond with the date registered by the health authority.

--- a/backend/src/main/resources/messages_en.properties
+++ b/backend/src/main/resources/messages_en.properties
@@ -49,6 +49,9 @@ Invalid.accountRegistrationDto.username=Invalid user name!
 Invalid.accountRegistrationDto.birthDate=Invalid date of birth!
 Invalid.accountRegistration.wrongBirthDate=Please check the date of birth entered! The date entered does not correspond with the date registered by the health authority.
 Invalid.accountRegistration.username=The user name entered is not permissible!
+Invalid.accountRegistration.clientCodeNotFound=The sign-in code you've used doesn't work. Please check if it is exactly the code you've received via email. If that isn't the case, please contact your health authority immediately via phone.
+Invalid.accountRegistration.clientCodeExpired=The sign-in code you've used is expired. Please contact your health authority to receive a new code. All codes are valid for 24 hours.
+Invalid.accountRegistration.clientCodeUsedOrCanceled=The sign-in code you've used isn't the most recent one or has been used before. Please check if you've received a newer code from your health authority.
 
 #Roles
 quarano.account.RoleType.role-hd-admin=Admin


### PR DESCRIPTION
Added i18n messages for ActivationCodeExceptions to display localized messages in frontend when activation code is expired, not found or already used.

Includes german and english version of messages.