### PR TITLE
CORE-487 Integrates an endpoint that returns CSV data of cases with quarantine

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -24,6 +24,8 @@
 		<spring-hateoas.version>1.2.0-RC1</spring-hateoas.version>
 		<greenmail.version>1.6.0</greenmail.version>
 		<refdocs.version>0.2.2.RELEASE</refdocs.version>
+		<xmlprojector.version>1.4.17</xmlprojector.version>
+		<opencsv.version>5.3</opencsv.version>
 		<refdocs.dir>${project.build.directory}/refdocs</refdocs.dir>
 	</properties>
 
@@ -267,8 +269,15 @@
 		<dependency>
 			<groupId>org.xmlbeam</groupId>
 			<artifactId>xmlprojector</artifactId>
-			<version>1.4.17</version>
+			<version>${xmlprojector.version}</version>
 		</dependency>
+
+		<!-- For CSV import/export -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>${opencsv.version}</version>
+        </dependency>
 
 		<!-- Development-only dependencies -->
 

--- a/backend/src/main/asciidoc/api.adoc
+++ b/backend/src/main/asciidoc/api.adoc
@@ -73,3 +73,19 @@ include::{snippets}/getting-started/agent-user-home/links.adoc[]
 
 include::api-agent.adoc[leveloffset=+1]
 include::api-user.adoc[leveloffset=+1]
+
+== CSV Import/Export
+
+=== Quarantine Export
+
+include::{snippets}/csv-import-export/quarantine-order/auto-description.adoc[]
+
+include::{snippets}/csv-import-export/quarantine-order/curl-request.adoc[]
+
+The request takes the following attributes:
+
+include::{snippets}/csv-import-export/quarantine-order/auto-request-parameters.adoc[]
+
+That call will return a 200 OK and contain the CSV data as body.
+
+include::{snippets}/csv-import-export/quarantine-order/response-body.adoc[]

--- a/backend/src/main/java/quarano/department/TrackedCase.java
+++ b/backend/src/main/java/quarano/department/TrackedCase.java
@@ -30,6 +30,9 @@ import org.springframework.data.util.Streamable;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
+import com.querydsl.core.annotations.QueryEntity;
+import com.querydsl.core.annotations.QueryInit;
+
 /**
  * @author Oliver Drotbohm
  * @author Michael J. Simons
@@ -43,9 +46,11 @@ import org.springframework.util.Assert;
 @Slf4j
 public class TrackedCase extends QuaranoAggregate<TrackedCase, TrackedCaseIdentifier> {
 
-	@OneToOne(cascade = { CascadeType.ALL }) @JoinColumn(name = "tracked_person_id") private TrackedPerson trackedPerson;
+	@QueryInit({ "*.*", "address.zipCode", "department.id" })
+	@OneToOne(cascade = { CascadeType.ALL })	@JoinColumn(name = "tracked_person_id")	private TrackedPerson trackedPerson;
 
-	@ManyToOne @JoinColumn(name = "department_id", nullable = false) private Department department;
+	@QueryInit({ "*.*", "id" })
+	@ManyToOne	@JoinColumn(name = "department_id", nullable = false)	private Department department;
 
 	private @Getter TestResult testResult;
 

--- a/backend/src/main/java/quarano/department/TrackedCaseQuerydslFilters.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseQuerydslFilters.java
@@ -2,15 +2,18 @@ package quarano.department;
 
 import quarano.account.Department.DepartmentIdentifier;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.util.Optionals;
 import org.springframework.data.util.Streamable;
 import org.springframework.util.Assert;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.DateExpression;
 
 /**
  * Manual implementations of Querydsl-based queries. {@link QuerydslPredicateExecutor} was not an option as we need to
@@ -22,12 +25,16 @@ public interface TrackedCaseQuerydslFilters {
 
 	Streamable<TrackedCase> findFiltered(Optional<String> query, Optional<String> type, DepartmentIdentifier id);
 
+	Streamable<TrackedCase> findFilteredByQuarantine(Optional<LocalDate> quarantineChangedFrom,
+			Optional<LocalDate> quarantineChangedTo, Optional<String> type, DepartmentIdentifier id);
+
 	static class TrackedCaseQuerydslFiltersImpl extends QuerydslRepositorySupport implements TrackedCaseQuerydslFilters {
 
 		public TrackedCaseQuerydslFiltersImpl() {
 			super(TrackedCase.class);
 		}
 
+		@Override
 		public Streamable<TrackedCase> findFiltered(Optional<String> query, Optional<String> type,
 				DepartmentIdentifier id) {
 
@@ -51,6 +58,56 @@ public interface TrackedCaseQuerydslFilters {
 					.leftJoin($case.originCases).fetchJoin()
 					.where(predicate)
 					.orderBy($casePerson.lastName.asc(), $casePerson.firstName.asc());
+
+			return Streamable.of(jpql.fetch());
+		}
+
+		/**
+		 * Returns all {@link TrackedCase} of the given department that currently have a quarantine and whose quarantine has
+		 * been changed in the range of the two date parameters {@code quarantineChangedFrom} and
+		 * {@code quarantineChangedFrom} and whose {@link CaseType} represented by the give type constraint.
+		 *
+		 * @param quarantineChangedFrom must not be {@literal null}.
+		 * @param quarantineChangedTo must not be {@literal null}.
+		 * @param type must not be {@literal null}.
+		 * @param id must not be {@literal null}.
+		 * @return
+		 */
+		@Override
+		public Streamable<TrackedCase> findFilteredByQuarantine(Optional<LocalDate> quarantineChangedFrom,
+				Optional<LocalDate> quarantineChangedTo, Optional<String> type, DepartmentIdentifier id) {
+
+			Assert.notNull(quarantineChangedFrom, "Quarantine changed from must not be null!");
+			Assert.notNull(quarantineChangedTo, "Quarantine changed to must not be null!");
+			Assert.notNull(type, "Type constraint must not be null!");
+			Assert.notNull(id, "Department identifier must not be null!");
+
+			var $case = QTrackedCase.trackedCase;
+			var $casePerson = $case.trackedPerson;
+			var $address = $casePerson.address;
+			var $zipCode = $address.zipCode;
+
+			var builder = new BooleanBuilder($case.quarantine.lastModified.isNotNull());
+
+			if (Optionals.isAnyPresent(quarantineChangedFrom, quarantineChangedTo)) {
+
+				builder = builder.and($case.quarantine.lastModified
+						.between(
+								quarantineChangedFrom.map(LocalDate::atStartOfDay).orElse(null),
+								quarantineChangedTo.map(it -> it.plusDays(1)).map(LocalDate::atStartOfDay).orElse(null)));
+			}
+
+			var predicate = builder
+					.and(DateExpression.currentDate(LocalDate.class).between($case.quarantine.from, $case.quarantine.to))
+					.and(applyCaseType(type))
+					.and($case.department.id.eq(id));
+
+			var jpql = from($case)
+					.join($casePerson).fetchJoin()
+					.leftJoin($case.questionnaire).fetchJoin()
+					.leftJoin($case.originCases).fetchJoin()
+					.where(predicate)
+					.orderBy($zipCode.value.asc().nullsLast(), $casePerson.lastName.asc(), $casePerson.firstName.asc());
 
 			return Streamable.of(jpql.fetch());
 		}

--- a/backend/src/main/java/quarano/department/csv/TrackedCaseCsvController.java
+++ b/backend/src/main/java/quarano/department/csv/TrackedCaseCsvController.java
@@ -1,0 +1,63 @@
+package quarano.department.csv;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import quarano.account.Department;
+import quarano.core.web.LoggedIn;
+import quarano.department.TrackedCaseRepository;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Jens Kutzsche
+ */
+@RestController
+@RequiredArgsConstructor
+public class TrackedCaseCsvController {
+
+	private final @NonNull TrackedCaseRepository caseRepo;
+	private final @NonNull TrackedCaseCsvRepresentations representations;
+
+	/**
+	 * <p>
+	 * After the login as staff of the health department, the cases with a currently running quarantine can be exported.
+	 * This is mainly intended for creating quarantine orders.
+	 * </p>
+	 * <p>
+	 * The quantity of exported cases can be limited by the type and date of the last quarantine modification. For
+	 * example, only quarantines created or modified in the last 24 hours can be exported.
+	 * </p>
+	 * 
+	 * @param department
+	 * @param quarantineFrom The date (YYYY-MM-DD) of the last quarantine modification from which (inclusive) the cases
+	 *          should be included in the export.
+	 * @param quarantineTo The date (YYYY-MM-DD) of the last quarantine modification up to which (inclusive) the cases
+	 *          should be included in the export.
+	 * @param type The case type (INDEX or CONTACT) of the cases to be exported.
+	 * @param response
+	 * @throws IOException
+	 */
+	@GetMapping(path = "/api/hd/quarantineorder", produces = "text/csv")
+	public void getQuarantineOrder(@LoggedIn Department department,
+			@RequestParam("from") @DateTimeFormat(iso = ISO.DATE) Optional<LocalDate> quarantineFrom,
+			@RequestParam("to") @DateTimeFormat(iso = ISO.DATE) Optional<LocalDate> quarantineTo,
+			@RequestParam("type") Optional<String> type,
+			HttpServletResponse response) throws IOException {
+
+		response.setContentType("text/csv");
+
+		var cases = caseRepo.findFilteredByQuarantine(quarantineFrom, quarantineTo, type, department.getId());
+
+		representations.writeQuarantineOrderCsv(response.getWriter(), cases.stream());
+	}
+}

--- a/backend/src/main/java/quarano/department/csv/TrackedCaseCsvRepresentations.java
+++ b/backend/src/main/java/quarano/department/csv/TrackedCaseCsvRepresentations.java
@@ -1,0 +1,145 @@
+package quarano.department.csv;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import quarano.department.TrackedCase;
+import quarano.tracking.Address;
+import quarano.tracking.Quarantine;
+
+import java.io.PrintWriter;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.stereotype.Component;
+
+import com.opencsv.CSVWriter;
+import com.opencsv.bean.CsvBindByName;
+import com.opencsv.bean.HeaderColumnNameMappingStrategy;
+import com.opencsv.bean.StatefulBeanToCsvBuilder;
+import com.opencsv.exceptions.CsvDataTypeMismatchException;
+import com.opencsv.exceptions.CsvRequiredFieldEmptyException;
+
+/**
+ * @author Jens Kutzsche
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TrackedCaseCsvRepresentations {
+
+	private static final String LAST_NAME = "LAST NAME";
+	private static final String FIRST_NAME = "FIRST NAME";
+	private static final String DATE_OF_BIRTH = "DATE OF BIRTH";
+	private static final String EMAIL = "EMAIL ADDRESS";
+	private static final String PHONE = "PHONE NUMBER";
+	private static final String MOBILE = "MOBILE NUMBER";
+	private static final String CITY = "CITY";
+	private static final String ZIP_CODE = "ZIP CODE";
+	private static final String STREET = "STREET";
+	private static final String HOUSE_NUMBER = "HOUSE NUMBER";
+	private static final String QUARANTINE_FROM = "QUARANTINE FROM";
+	private static final String QUARANTINE_TO = "QUARANTINE TO";
+	private static final String QUARANTINE_CHANGED = "QUARANTINE LAST MODIFIED";
+	private static final String TYPE = "TYPE";
+
+	static final String[] CSV_ORDER = { TYPE, LAST_NAME, FIRST_NAME, DATE_OF_BIRTH, CITY, ZIP_CODE, STREET,
+			HOUSE_NUMBER, EMAIL, PHONE, MOBILE, QUARANTINE_FROM, QUARANTINE_TO, QUARANTINE_CHANGED };
+
+	public void writeQuarantineOrderCsv(PrintWriter writer, Stream<TrackedCase> cases) {
+
+		var csvCases = cases.map(QuarantineOrderCsv::new);
+
+		try {
+
+			var mappingStrategy = new HeaderColumnNameMappingStrategy<QuarantineOrderCsv>();
+			mappingStrategy.setType(QuarantineOrderCsv.class);
+			mappingStrategy.setColumnOrderOnWrite(createOrderComparatorFor(CSV_ORDER));
+
+			var beanToCsv = new StatefulBeanToCsvBuilder<QuarantineOrderCsv>(writer)
+					.withMappingStrategy(mappingStrategy)
+					.withSeparator(';')
+					.withQuotechar(CSVWriter.NO_QUOTE_CHARACTER)
+					.withEscapechar(CSVWriter.DEFAULT_ESCAPE_CHARACTER)
+					.withLineEnd(CSVWriter.DEFAULT_LINE_END)
+					.build();
+
+			beanToCsv.write(csvCases);
+
+		} catch (CsvDataTypeMismatchException | CsvRequiredFieldEmptyException e) {
+			log.error("Error mapping Bean to CSV", e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Comparator<String> createOrderComparatorFor(String[] orderArray) {
+		return Comparator.comparingInt(it -> ArrayUtils.indexOf(orderArray, it));
+	}
+
+	public static class QuarantineOrderCsv {
+
+		@CsvBindByName(column = LAST_NAME)
+		private final @Getter String lastName;
+		@CsvBindByName(column = FIRST_NAME)
+		private final @Getter String firstName;
+		@CsvBindByName(column = DATE_OF_BIRTH)
+		private final @Getter String dateOfBirth;
+		@CsvBindByName(column = EMAIL)
+		private final @Getter String email;
+		@CsvBindByName(column = PHONE)
+		private final @Getter String phone;
+		@CsvBindByName(column = MOBILE)
+		private final @Getter String mobile;
+		@CsvBindByName(column = CITY)
+		private final @Getter String city;
+		@CsvBindByName(column = ZIP_CODE)
+		private final @Getter String zipCode;
+		@CsvBindByName(column = STREET)
+		private final @Getter String street;
+		@CsvBindByName(column = HOUSE_NUMBER)
+		private final @Getter String houseNumber;
+		@CsvBindByName(column = QUARANTINE_FROM)
+		private final @Getter String quarantineFrom;
+		@CsvBindByName(column = QUARANTINE_TO)
+		private final @Getter String quarantineTo;
+		@CsvBindByName(column = TYPE)
+		private final @Getter String type;
+		@CsvBindByName(column = QUARANTINE_CHANGED)
+		private final @Getter String quarantineChanged;
+
+		public QuarantineOrderCsv(TrackedCase trackedCase) {
+
+			DateTimeFormatter localizer = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM);
+			DateTimeFormatter localizerDateTime = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
+
+			var trackedPerson = trackedCase.getTrackedPerson();
+			lastName = trackedPerson.getLastName();
+			firstName = trackedPerson.getFirstName();
+			email = Objects.toString(trackedPerson.getEmailAddress(), null);
+			phone = Objects.toString(trackedPerson.getPhoneNumber(), null);
+			mobile = Objects.toString(trackedPerson.getMobilePhoneNumber(), null);
+
+			var birth = Optional.ofNullable(trackedPerson.getDateOfBirth());
+			dateOfBirth = birth.map(it -> it.format(localizer)).orElse(null);
+
+			var address = Optional.ofNullable(trackedPerson.getAddress());
+			city = address.map(Address::getCity).orElse(null);
+			zipCode = address.map(Address::getZipCode).map(it -> Objects.toString(it, null)).orElse(null);
+			street = address.map(Address::getStreet).orElse(null);
+			houseNumber = address.map(Address::getHouseNumber).map(it -> Objects.toString(it)).orElse(null);
+
+			var quarantine = Optional.ofNullable(trackedCase.getQuarantine());
+			quarantineFrom = quarantine.map(Quarantine::getFrom).map(it -> it.format(localizer)).orElse(null);
+			quarantineTo = quarantine.map(Quarantine::getTo).map(it -> it.format(localizer)).orElse(null);
+			quarantineChanged = quarantine.map(Quarantine::getLastModified).map(it -> it.format(localizerDateTime))
+					.orElse(null);
+
+			type = trackedCase.getType().getPrimaryCaseType().toString();
+		}
+	}
+}

--- a/backend/src/main/java/quarano/tracking/Quarantine.java
+++ b/backend/src/main/java/quarano/tracking/Quarantine.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import javax.persistence.Column;
@@ -17,7 +18,7 @@ import javax.persistence.Embeddable;
 @Data
 @Embeddable
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor(staticName = "of")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Quarantine {
 
 	private static final ZoneId ZONE_BERLIN = ZoneId.of("Europe/Berlin");
@@ -27,6 +28,13 @@ public class Quarantine {
 
 	@Column(name = "quarantine_to")
 	private final LocalDate to;
+
+	@Column(name = "quarantine_last_modified")
+	private final LocalDateTime lastModified;
+
+	public static Quarantine of(LocalDate from, LocalDate to) {
+		return new Quarantine(from, to, LocalDateTime.now());
+	}
 
 	public boolean isOver() {
 		return LocalDate.now(ZONE_BERLIN).isAfter(to);

--- a/backend/src/main/resources/db/migration/V1012__Add_quaranine_last_modified.sql
+++ b/backend/src/main/resources/db/migration/V1012__Add_quaranine_last_modified.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracked_cases ADD quarantine_last_modified timestamp DEFAULT CURRENT_TIMESTAMP NULL;

--- a/backend/src/test/java/quarano/department/csv/TrackedCaseCsvControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/csv/TrackedCaseCsvControllerWebIntegrationTests.java
@@ -1,0 +1,114 @@
+package quarano.department.csv;
+
+import static java.time.format.DateTimeFormatter.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import quarano.AbstractDocumentation;
+import quarano.DocumentationFlow;
+import quarano.QuaranoWebIntegrationTest;
+import quarano.WithQuaranoUser;
+
+import java.io.UnsupportedEncodingException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultHandler;
+
+/**
+ * @author Jens Kutzsche
+ */
+@QuaranoWebIntegrationTest
+@WithQuaranoUser("admin")
+public class TrackedCaseCsvControllerWebIntegrationTests extends AbstractDocumentation {
+
+	private String header;
+
+	@BeforeAll
+	void beforeAll() {
+		header = Arrays.stream(TrackedCaseCsvRepresentations.CSV_ORDER).collect(Collectors.joining(";"));
+	}
+
+	@ParameterizedTest(name = "{index} get quarantine order for type {0}; from {1}; to {2}")
+	@MethodSource("quarantineParams")
+	void getQuarantineOrder(String type, String from, String to, int resultSize, boolean createDoku) throws Exception {
+
+		var result = performGetAndExpect200(type, from, to, createDoku);
+
+		assertThat(result.lines()).size().isEqualTo(resultSize);
+
+		if (resultSize != 0) {
+			assertThat(result.lines()).first().isEqualTo(header);
+		}
+	}
+
+	@ParameterizedTest(name = "{index} get quarantine order for type {0}; from {1}; to {2}")
+	@MethodSource("wrongParams")
+	void getQuarantineOrderWithErrors(String type, String from, String to) throws Exception {
+		performGetAndExpect400(type, from, to);
+	}
+
+	private Stream<Arguments> quarantineParams() {
+		return Stream.of(
+				arguments(null, null, null, 15, false),
+				arguments("index", null, null, 15, false),
+				arguments("contact", null, null, 0, false),
+				arguments("wrongType", null, null, 15, false),
+				arguments("index", LocalDate.now().format(ISO_DATE), null, 15, false),
+				arguments("index", LocalDate.now().plusDays(1).format(ISO_DATE), null, 0, false),
+				arguments("index", null, LocalDate.now().format(ISO_DATE), 15, false),
+				arguments("index", null, LocalDate.now().minusDays(1).format(ISO_DATE), 0, false),
+				arguments("index", LocalDate.now().format(ISO_DATE), LocalDate.now().format(ISO_DATE), 15, false),
+				arguments("index", LocalDate.now().minusDays(1).format(ISO_DATE), LocalDate.now().plusDays(1).format(ISO_DATE),
+						15, true),
+				arguments("index", LocalDate.now().plusDays(1).format(ISO_DATE), LocalDate.now().minusDays(1).format(ISO_DATE),
+						0, false));
+	}
+
+	private Stream<Arguments> wrongParams() {
+		return Stream.of(
+				arguments(null, LocalDate.now().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)), null),
+				arguments(null, null, LocalDate.now().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))));
+	}
+
+	private String performGetAndExpect200(String type, String from, String to, boolean createDoku)
+			throws UnsupportedEncodingException, Exception {
+
+		return mvc.perform(get("/api/hd/quarantineorder")
+				.contentType(MediaType.valueOf("text/csv"))
+				.param("type", type)
+				.param("from", from)
+				.param("to", to))
+				.andDo(documentGetQuarantineOrder(createDoku))
+				.andExpect(status().is2xxSuccessful())
+				.andReturn().getResponse().getContentAsString();
+	}
+
+	private void performGetAndExpect400(String type, String from, String to)
+			throws UnsupportedEncodingException, Exception {
+
+		mvc.perform(get("/api/hd/quarantineorder")
+				.contentType(MediaType.valueOf("text/csv"))
+				.param("type", type)
+				.param("from", from)
+				.param("to", to))
+				.andExpect(status().is4xxClientError());
+	}
+
+	private static ResultHandler documentGetQuarantineOrder(boolean createDoku) {
+		return createDoku
+				? DocumentationFlow.of("csv-import-export").document("quarantine-order")
+				: result -> {};
+	}
+}


### PR DESCRIPTION
- Extends class Quarantine (and the DB model) with a lastModified date
to determine at a certain time changed data records.
- The new endpoint exports all cases that currently have a quarantine.
- The export format is a CSV.
- The exported cases can optionally be qualified by the quarantine
modification date or by the case type.