### PR TITLE
Removing superfluous /api from backend request mappings

### DIFF
--- a/backend/src/docs/java/quarano/auth/GettingStartedDocumentation.java
+++ b/backend/src/docs/java/quarano/auth/GettingStartedDocumentation.java
@@ -56,7 +56,7 @@ class GettingStartedDocumentation extends AbstractDocumentation {
 
 		var payload = Map.of("username", "agent1", "password", "agent1");
 
-		var response = mvc.perform(post("/api/login")
+		var response = mvc.perform(post("/login")
 				.content(jackson.writeValueAsString(payload)))
 				.andExpect(status().isOk())
 				.andExpect(header().string(QuaranoHttpHeaders.AUTH_TOKEN, is(notNullValue())))

--- a/backend/src/main/java/quarano/account/web/StaffAccountController.java
+++ b/backend/src/main/java/quarano/account/web/StaffAccountController.java
@@ -46,7 +46,7 @@ class StaffAccountController {
 	private final @NonNull AccountService accounts;
 	private final @NonNull StaffAccountRepresentations representations;
 
-	@PostMapping("/api/hd/accounts")
+	@PostMapping("/hd/accounts")
 	HttpEntity<?> addStaffAccount(@Valid @RequestBody StaffAccountCreateInputDto payload,
 			Errors errors,
 			@LoggedIn Department department) {
@@ -75,7 +75,7 @@ class StaffAccountController {
 				});
 	}
 
-	@PutMapping("/api/hd/accounts/{accountId}/password")
+	@PutMapping("/hd/accounts/{accountId}/password")
 	HttpEntity<?> putStaffAccountPassword(@PathVariable AccountIdentifier accountId,
 			@Valid @RequestBody NewPassword payload, Errors errors, @LoggedIn Account admin) {
 
@@ -89,7 +89,7 @@ class StaffAccountController {
 				});
 	}
 
-	@PutMapping("/api/hd/accounts/{accountId}")
+	@PutMapping("/hd/accounts/{accountId}")
 	HttpEntity<?> updateStaffAccount(@PathVariable AccountIdentifier accountId,
 			@Validated @RequestBody StaffAccountUpdateInputDto payload,
 			Errors errors,
@@ -110,7 +110,7 @@ class StaffAccountController {
 				}).concludeIfValid(ResponseEntity::of);
 	}
 
-	@GetMapping(path = "/api/hd/accounts", produces = MediaTypes.HAL_JSON_VALUE)
+	@GetMapping(path = "/hd/accounts", produces = MediaTypes.HAL_JSON_VALUE)
 	RepresentationModel<?> getStaffAccounts(@LoggedIn Account admin) {
 
 		var departmentAccounts = accounts.findStaffAccountsFor(admin.getDepartmentId());
@@ -120,7 +120,7 @@ class StaffAccountController {
 				.collect(Collectors.collectingAndThen(Collectors.toUnmodifiableList(), CollectionModel::of));
 	}
 
-	@GetMapping(path = "/api/hd/accounts/{accountId}", produces = MediaTypes.HAL_JSON_VALUE)
+	@GetMapping(path = "/hd/accounts/{accountId}", produces = MediaTypes.HAL_JSON_VALUE)
 	ResponseEntity<?> getStaffAccount(@PathVariable AccountIdentifier accountId, @LoggedIn Account admin) {
 
 		var adminDepartmentId = admin.getDepartmentId();
@@ -130,7 +130,7 @@ class StaffAccountController {
 				.map(it -> representations.toSummary(it)));
 	}
 
-	@DeleteMapping("/api/hd/accounts/{accountId}")
+	@DeleteMapping("/hd/accounts/{accountId}")
 	HttpEntity<?> deleteStaffAccounts(@PathVariable AccountIdentifier accountId, @LoggedIn Account admin) {
 
 		return accounts.findById(accountId)

--- a/backend/src/main/java/quarano/actions/web/AnomaliesController.java
+++ b/backend/src/main/java/quarano/actions/web/AnomaliesController.java
@@ -42,7 +42,7 @@ public class AnomaliesController {
 	private final @NonNull TrackedCaseRepository cases;
 	private final @NonNull AnomaliesRepresentations representations;
 
-	@GetMapping("/api/hd/actions/{identifier}")
+	@GetMapping("/hd/actions/{identifier}")
 	HttpEntity<CaseActionsRepresentation> getAnomalies(@PathVariable TrackedCaseIdentifier identifier,
 			@LoggedIn DepartmentIdentifier department) {
 
@@ -51,7 +51,7 @@ public class AnomaliesController {
 				.map(this::toRepresentation));
 	}
 
-	@PutMapping("/api/hd/actions/{identifier}/resolve")
+	@PutMapping("/hd/actions/{identifier}/resolve")
 	HttpEntity<?> resolveActions(@PathVariable TrackedCaseIdentifier identifier,
 			@Valid @RequestBody ActionsReviewed payload, Errors errors,
 			@LoggedIn DepartmentIdentifier department) {
@@ -67,7 +67,7 @@ public class AnomaliesController {
 				.concludeIfValid(__ -> getAnomalies(identifier, department));
 	}
 
-	@GetMapping("/api/hd/actions")
+	@GetMapping("/hd/actions")
 	public RepresentationModel<?> getAllCasesByAnomalies(@LoggedIn Department department) {
 
 		var actionRepresentations = cases.findByDepartmentId(department.getId())

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -47,7 +47,7 @@ public class RegistrationController {
 
 	private final @NonNull RegistrationRepresentations representations;
 
-	@PostMapping("/api/registration")
+	@PostMapping("/registration")
 	public HttpEntity<?> registerClient(@Valid @RequestBody RegistrationDto payload, Errors errors,
 			HttpServletRequest request) {
 
@@ -58,7 +58,7 @@ public class RegistrationController {
 				.concludeSelfIfValid((p, e) -> doRegisterClient(p, e, locale));
 	}
 
-	@PutMapping("/api/hd/cases/{id}/registration")
+	@PutMapping("/hd/cases/{id}/registration")
 	public HttpEntity<?> createRegistration(@PathVariable TrackedCaseIdentifier id, @LoggedIn Account account) {
 
 		var trackedCase = cases.findById(id).orElse(null);
@@ -74,7 +74,7 @@ public class RegistrationController {
 						it -> ResponseEntity.ok(it));
 	}
 
-	@GetMapping("/api/hd/cases/{id}/registration")
+	@GetMapping("/hd/cases/{id}/registration")
 	HttpEntity<?> getRegistrationDetails(@PathVariable TrackedCaseIdentifier id, @LoggedIn Account account) {
 
 		return cases.findById(id)
@@ -88,7 +88,7 @@ public class RegistrationController {
 	 *
 	 * @return true if the code exists, error-json otherwise
 	 */
-	@GetMapping("api/registration/checkcode/{activationCode}")
+	@GetMapping("/registration/checkcode/{activationCode}")
 	public ResponseEntity<Boolean> doesClientexist(@PathVariable UUID activationCode) {
 
 		return ResponseEntity.ok(activationCodes.getValidCode(ActivationCodeIdentifier.of(activationCode))
@@ -100,7 +100,7 @@ public class RegistrationController {
 	 *
 	 * @return true if the username is available and valid, error JSON otherwise
 	 */
-	@GetMapping("api/registration/checkusername/{userName}")
+	@GetMapping("/registration/checkusername/{userName}")
 	public ResponseEntity<Boolean> checkUserName(@PathVariable String userName) {
 		return ResponseEntity.ok(registration.isUsernameAvailable(userName));
 	}

--- a/backend/src/main/java/quarano/department/web/TrackedCaseController.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseController.java
@@ -70,7 +70,7 @@ public class TrackedCaseController {
 	private final @NonNull TrackedCaseRepresentations representations;
 	private final @NonNull HealthDepartments rkiDepartments;
 
-	@GetMapping(path = "/api/hd/cases")
+	@GetMapping(path = "/hd/cases")
 	public RepresentationModel<?> getCases(@LoggedIn Department department,
 			@RequestParam("q") Optional<String> query,
 			@RequestParam("projection") Optional<String> projection,
@@ -87,20 +87,20 @@ public class TrackedCaseController {
 				.build();
 	}
 
-	@PostMapping(path = "/api/hd/cases", params = "type=contact")
+	@PostMapping(path = "/hd/cases", params = "type=contact")
 	HttpEntity<?> postContactCase(@ValidatedContactCase @RequestBody TrackedCaseDto.Input payload, Errors errors,
 			@LoggedIn Department department) {
 		return createTrackedCase(payload, CaseType.CONTACT, department, errors);
 	}
 
-	@PostMapping(path = "/api/hd/cases", params = "type=index")
+	@PostMapping(path = "/hd/cases", params = "type=index")
 	HttpEntity<?> postIndexCase(@ValidatedIndexCase @RequestBody TrackedCaseDto.Input payload, Errors errors,
 			@LoggedIn Department department) {
 
 		return postCase(payload, errors, department);
 	}
 
-	@PostMapping("/api/hd/cases")
+	@PostMapping("/hd/cases")
 	HttpEntity<?> postCase(@ValidatedIndexCase @RequestBody TrackedCaseDto.Input payload, Errors errors,
 			@LoggedIn Department department) {
 
@@ -124,13 +124,13 @@ public class TrackedCaseController {
 				});
 	}
 
-	@GetMapping(path = "/api/hd/cases/form")
+	@GetMapping(path = "/hd/cases/form")
 	HttpEntity<?> getCaseForm() {
 
 		return ResponseEntity.ok(TrackedCaseDefaults.of(configuration));
 	}
 
-	@GetMapping("/api/hd/cases/{identifier}")
+	@GetMapping("/hd/cases/{identifier}")
 	public HttpEntity<?> getCase(@PathVariable TrackedCaseIdentifier identifier, @LoggedIn Department department) {
 
 		return ResponseEntity.of(cases.findById(identifier)
@@ -138,7 +138,7 @@ public class TrackedCaseController {
 				.map(representations::toRepresentation));
 	}
 
-	@GetMapping("/api/hd/cases/{identifier}/questionnaire")
+	@GetMapping("/hd/cases/{identifier}/questionnaire")
 	HttpEntity<?> getQuestionnaire(@PathVariable TrackedCaseIdentifier identifier, @LoggedIn Department department) {
 
 		return ResponseEntity.of(cases.findById(identifier)
@@ -147,7 +147,7 @@ public class TrackedCaseController {
 				.map(representations::toRepresentation));
 	}
 
-	@GetMapping("/api/hd/cases/{identifier}/diary")
+	@GetMapping("/hd/cases/{identifier}/diary")
 	HttpEntity<?> getDiaryOfCase(@PathVariable TrackedCaseIdentifier identifier,
 			@LoggedIn DepartmentIdentifier departmentIdentifier) {
 
@@ -164,7 +164,7 @@ public class TrackedCaseController {
 				.build());
 	}
 
-	@GetMapping("/api/hd/cases/{identifier}/contacts")
+	@GetMapping("/hd/cases/{identifier}/contacts")
 	HttpEntity<?> getContactsOfCase(@PathVariable TrackedCaseIdentifier identifier,
 			@LoggedIn DepartmentIdentifier department) {
 
@@ -183,7 +183,7 @@ public class TrackedCaseController {
 
 	// PUT Mapping for transformation into index case
 
-	@PutMapping("/api/hd/cases/{identifier}")
+	@PutMapping("/hd/cases/{identifier}")
 	HttpEntity<?> putCase(@PathVariable TrackedCaseIdentifier identifier,
 			@RequestBody TrackedCaseDto.Input payload,
 			Errors errors) {
@@ -198,7 +198,7 @@ public class TrackedCaseController {
 				.concludeIfValid(ResponseEntity::ok);
 	}
 
-	@DeleteMapping("/api/hd/cases/{identifier}")
+	@DeleteMapping("/hd/cases/{identifier}")
 	HttpEntity<?> concludeCase(@PathVariable TrackedCaseIdentifier identifier,
 			@LoggedIn DepartmentIdentifier department) {
 
@@ -208,7 +208,7 @@ public class TrackedCaseController {
 				.map(cases::save));
 	}
 
-	@PostMapping("/api/hd/cases/{identifier}/comments")
+	@PostMapping("/hd/cases/{identifier}/comments")
 	HttpEntity<?> postComment(@PathVariable TrackedCaseIdentifier identifier, @LoggedIn Account account,
 			@Valid @RequestBody CommentInput payload, Errors errors) {
 
@@ -225,7 +225,7 @@ public class TrackedCaseController {
 				.concludeIfValid(ResponseEntity::ok);
 	}
 
-	@GetMapping("/api/enrollments")
+	@GetMapping("/enrollments")
 	Stream<?> allEnrollments() {
 
 		return cases.findAll()
@@ -234,7 +234,7 @@ public class TrackedCaseController {
 				.stream();
 	}
 
-	@GetMapping("/api/enrollment")
+	@GetMapping("/enrollment")
 	public HttpEntity<?> enrollment(@LoggedIn TrackedPerson person) {
 
 		var map = cases.findByTrackedPerson(person)
@@ -244,7 +244,7 @@ public class TrackedCaseController {
 		return ResponseEntity.of(map);
 	}
 
-	@PutMapping("/api/enrollment/details")
+	@PutMapping("/enrollment/details")
 	HttpEntity<?> submitEnrollmentDetails(
 			@Validated @RequestBody TrackedPersonDto dto, Errors errors, @RequestParam(required = false) boolean confirmed,
 			@LoggedIn TrackedPerson user) {
@@ -287,7 +287,7 @@ public class TrackedCaseController {
 				});
 	}
 
-	@GetMapping("/api/enrollment/questionnaire")
+	@GetMapping("/enrollment/questionnaire")
 	HttpEntity<?> showQuestionaire(@LoggedIn TrackedPerson person) {
 
 		var report = cases.findByTrackedPerson(person)
@@ -300,7 +300,7 @@ public class TrackedCaseController {
 				.body(report);
 	}
 
-	@PutMapping(path = "/api/enrollment/questionnaire")
+	@PutMapping(path = "/enrollment/questionnaire")
 	HttpEntity<?> addQuestionaire(@Validated @RequestBody QuestionnaireDto dto, Errors errors,
 			@LoggedIn TrackedPerson person) {
 
@@ -325,7 +325,7 @@ public class TrackedCaseController {
 				});
 	}
 
-	@PostMapping("/api/enrollment/completion")
+	@PostMapping("/enrollment/completion")
 	HttpEntity<?> completeEnrollment(@LoggedIn TrackedPerson person,
 			@RequestParam("withoutEncounters") boolean withoutEncounters) {
 
@@ -342,7 +342,7 @@ public class TrackedCaseController {
 				.build();
 	}
 
-	@DeleteMapping("/api/enrollment/completion")
+	@DeleteMapping("/enrollment/completion")
 	HttpEntity<?> reopenEnrollment(@LoggedIn TrackedPerson person) {
 
 		cases.findByTrackedPerson(person)

--- a/backend/src/main/java/quarano/diary/web/DiaryController.java
+++ b/backend/src/main/java/quarano/diary/web/DiaryController.java
@@ -40,7 +40,7 @@ public class DiaryController {
 	private final @NonNull TrackedPersonRepository people;
 	private final @NonNull ContactPersonRepository contacts;
 
-	@GetMapping("/api/diary")
+	@GetMapping("/diary")
 	DiarySummary getDiary(@LoggedIn TrackedPerson person) {
 
 		var diary = diaries.findDiaryFor(person);
@@ -48,7 +48,7 @@ public class DiaryController {
 		return representations.toSummary(diary, person.getAccountRegistrationDate());
 	}
 
-	@PostMapping("/api/diary")
+	@PostMapping("/diary")
 	HttpEntity<?> addDiaryEntry(@Valid @RequestBody DiaryEntryInput payload, Errors errors,
 			@LoggedIn TrackedPerson person) {
 
@@ -60,7 +60,7 @@ public class DiaryController {
 		});
 	}
 
-	@GetMapping("/api/diary/{identifier}")
+	@GetMapping("/diary/{identifier}")
 	public ResponseEntity<?> getDiaryEntry(@PathVariable DiaryEntryIdentifier identifier,
 			@LoggedIn TrackedPerson person) {
 
@@ -71,7 +71,7 @@ public class DiaryController {
 		return ResponseEntity.of(dto);
 	}
 
-	@PutMapping("/api/diary/{identifier}")
+	@PutMapping("/diary/{identifier}")
 	HttpEntity<?> updateDiaryEntry(@PathVariable DiaryEntryIdentifier identifier,
 			@Valid @RequestBody DiaryEntryInput payload, Errors errors,
 			@LoggedIn TrackedPerson person) {

--- a/backend/src/main/java/quarano/diary/web/DiaryRepresentations.java
+++ b/backend/src/main/java/quarano/diary/web/DiaryRepresentations.java
@@ -235,7 +235,7 @@ class DiaryRepresentations {
 		public Map<String, Object> getLinks() {
 
 			if (!diary.containsCurrentEntry()) {
-				return Map.of("create", Map.of("href", "/api/diary/form"));
+				return Map.of("create", Map.of("href", "/diary/form"));
 			}
 
 			return Collections.emptyMap();

--- a/backend/src/main/java/quarano/masterdata/SymptomController.java
+++ b/backend/src/main/java/quarano/masterdata/SymptomController.java
@@ -26,7 +26,7 @@ class SymptomController {
 	 *
 	 * @return
 	 */
-	@GetMapping("/api/symptoms")
+	@GetMapping("/symptoms")
 	public Stream<SymptomDto> getSymptoms() {
 
 		return symptoms.findAll(BY_NAME_ASCENDING)

--- a/backend/src/main/java/quarano/masterdata/web/FrontendTextController.java
+++ b/backend/src/main/java/quarano/masterdata/web/FrontendTextController.java
@@ -25,7 +25,7 @@ public class FrontendTextController {
 
 	private final @NonNull FrontendTextRepresentations representations;
 
-	@GetMapping(path = "/api/frontendtexts")
+	@GetMapping(path = "/frontendtexts")
 	public RepresentationModel<?> getText(@RequestParam("key") Optional<String> key) {
 
 		var terms = new FrontendText("terms", Locale.GERMAN, AGB);

--- a/backend/src/main/java/quarano/security/web/AuthenticationController.java
+++ b/backend/src/main/java/quarano/security/web/AuthenticationController.java
@@ -44,7 +44,7 @@ class AuthenticationController {
 	private final @NonNull AccountRepresentations accountRepresentations;
 	private final @NonNull MessageSourceAccessor messages;
 
-	@PostMapping({ "/login", "/api/login" })
+	@PostMapping("/login")
 	HttpEntity<?> login(@RequestBody AuthenticationRequest request, HttpServletRequest httpRequest) {
 
 		UnencryptedPassword password = UnencryptedPassword.of(request.getPassword());

--- a/backend/src/main/java/quarano/security/web/QuaranoWebSecurityConfigurerAdapter.java
+++ b/backend/src/main/java/quarano/security/web/QuaranoWebSecurityConfigurerAdapter.java
@@ -68,16 +68,15 @@ public class QuaranoWebSecurityConfigurerAdapter extends WebSecurityConfigurerAd
 			it.mvcMatchers("/docs/**").permitAll();
 			it.mvcMatchers("/h2_console/**").permitAll();
 			it.mvcMatchers("/login").permitAll();
-			it.mvcMatchers("/api/frontendtexts").permitAll();
-			it.mvcMatchers("/api/hd/accounts/**").access("hasRole('" + RoleType.ROLE_HD_ADMIN + "')");
-			it.mvcMatchers("/api/hd/**").access(hasAnyRole(RoleType.ROLE_HD_CASE_AGENT, RoleType.ROLE_HD_ADMIN));
-			it.mvcMatchers("/api/login").permitAll();
-			it.mvcMatchers("/api/registration").permitAll();
-			it.mvcMatchers("/api/registration/checkcode/**").permitAll();
-			it.mvcMatchers("/api/registration/checkusername/**").permitAll();
-			it.mvcMatchers("/api/user/**").authenticated();
-			it.mvcMatchers("/api/symptoms").authenticated();
-			it.mvcMatchers("/api/**").access("hasRole('" + RoleType.ROLE_USER + "')");
+			it.mvcMatchers("/registration").permitAll();
+			it.mvcMatchers("/registration/checkcode/**").permitAll();
+			it.mvcMatchers("/registration/checkusername/**").permitAll();
+			it.mvcMatchers("/frontendtexts").permitAll();
+			it.mvcMatchers("/hd/accounts/**").access("hasRole('" + RoleType.ROLE_HD_ADMIN + "')");
+			it.mvcMatchers("/hd/**").access(hasAnyRole(RoleType.ROLE_HD_CASE_AGENT, RoleType.ROLE_HD_ADMIN));
+			it.mvcMatchers("/user/**").authenticated();
+			it.mvcMatchers("/symptoms").authenticated();
+			it.mvcMatchers("/**").access("hasRole('" + RoleType.ROLE_USER + "')");
 		});
 		// this will ignore only h2-console csrf, spring security 4+
 		httpSecurity.csrf().ignoringAntMatchers("/h2-console/**");

--- a/backend/src/main/java/quarano/tracking/web/ContactPersonController.java
+++ b/backend/src/main/java/quarano/tracking/web/ContactPersonController.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Transactional
 @RestController("newContactPersonController")
-@RequestMapping("/api/contacts")
+@RequestMapping("/contacts")
 @RequiredArgsConstructor
 public class ContactPersonController {
 

--- a/backend/src/main/java/quarano/tracking/web/TrackingController.java
+++ b/backend/src/main/java/quarano/tracking/web/TrackingController.java
@@ -53,17 +53,17 @@ public class TrackingController {
 	private final @NonNull MapperWrapper mapper;
 	private final @NonNull MessageSourceAccessor messages;
 
-	@GetMapping("/api/enrollment/details")
+	@GetMapping("/enrollment/details")
 	public HttpEntity<?> enrollmentOverview(@LoggedIn TrackedPerson person) {
 		return overview(person);
 	}
 
-	@GetMapping("/api/details")
+	@GetMapping("/details")
 	HttpEntity<?> overview(@LoggedIn TrackedPerson person) {
 		return ResponseEntity.ok(mapper.map(person, TrackedPersonDto.class));
 	}
 
-	@PutMapping("/api/details")
+	@PutMapping("/details")
 	public HttpEntity<?> updateTrackedPersonDetails(@Validated @RequestBody TrackedPersonDto dto, Errors errors,
 			@LoggedIn TrackedPerson user) {
 
@@ -73,7 +73,7 @@ public class TrackingController {
 				.onValidGet(() -> ResponseEntity.ok().build());
 	}
 
-	@GetMapping("/api/details/form")
+	@GetMapping("/details/form")
 	HttpEntity<?> trackedPersonForm() {
 
 		var properties = Map.of("zipCode", Map.of("regex", ZipCode.PATTERN),
@@ -84,7 +84,7 @@ public class TrackingController {
 		return ResponseEntity.ok(Map.of("properties", properties));
 	}
 
-	@GetMapping("/api/encounters")
+	@GetMapping("/encounters")
 	public RepresentationModel<?> getEncounters(@LoggedIn TrackedPerson person) {
 
 		var encounters = person.getEncounters().map(it -> EncounterDto.of(it, person))
@@ -93,7 +93,7 @@ public class TrackingController {
 		return RepresentationModel.of(encounters);
 	}
 
-	@PostMapping("/api/encounters")
+	@PostMapping("/encounters")
 	HttpEntity<?> addEncounters(@Valid @RequestBody NewEncounter payload, Errors errors, @LoggedIn TrackedPerson person) {
 
 		if (errors.hasErrors() && errors.hasFieldErrors("contact")) {
@@ -122,7 +122,7 @@ public class TrackingController {
 				});
 	}
 
-	@GetMapping("/api/encounters/{identifier}")
+	@GetMapping("/encounters/{identifier}")
 	HttpEntity<?> getEncounter(@PathVariable EncounterIdentifier identifier, @LoggedIn TrackedPerson person) {
 
 		return ResponseEntity.of(person.getEncounters()
@@ -130,7 +130,7 @@ public class TrackingController {
 				.map(it -> EncounterDto.of(it, person)));
 	}
 
-	@DeleteMapping("/api/encounters/{identifier}")
+	@DeleteMapping("/encounters/{identifier}")
 	HttpEntity<?> removeEncounter(@PathVariable EncounterIdentifier identifier, @LoggedIn TrackedPerson person) {
 
 		person.removeEncounter(identifier);

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -38,7 +38,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/user")
 public class UserController {
 
 	private final @NonNull TrackedPersonRepository trackedPersonRepository;

--- a/backend/src/test/java/quarano/account/web/StaffAccountControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/account/web/StaffAccountControllerWebIntegrationTests.java
@@ -50,7 +50,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var referenceAgentAccount = accounts.findByUsername("agent1");
 		var referenceNonDepartmentAccount = accounts.findByUsername("DemoAccount");
 
-		var response = mvc.perform(get("/api/hd/accounts"))
+		var response = mvc.perform(get("/hd/accounts"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -74,7 +74,7 @@ class StaffAccountControllerWebIntegrationTests {
 	@WithQuaranoUser("agent1")
 	void getAccountServicesForbiddenForNonAdminHDUser() throws Exception {
 
-		mvc.perform(get("/api/hd/accounts"))
+		mvc.perform(get("/hd/accounts"))
 				.andExpect(status().isForbidden());
 	}
 
@@ -82,7 +82,7 @@ class StaffAccountControllerWebIntegrationTests {
 	@WithQuaranoUser("DemoAccount")
 	void getAccountsForbiddenForTrackedUser() throws Exception {
 
-		mvc.perform(get("/api/hd/accounts"))
+		mvc.perform(get("/hd/accounts"))
 				.andExpect(status().isForbidden())
 				.andReturn().getResponse().getContentAsString();
 	}
@@ -94,7 +94,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var source = createTestUserInput(RoleType.ROLE_HD_CASE_AGENT, RoleType.ROLE_HD_ADMIN);
 
 		// send request
-		var result = mvc.perform(post("/api/hd/accounts")
+		var result = mvc.perform(post("/hd/accounts")
 				.content(jackson.writeValueAsString(source))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated())
@@ -130,7 +130,7 @@ class StaffAccountControllerWebIntegrationTests {
 				.setLastName("Huber123");
 
 		// send request
-		var responseBody = mvc.perform(post("/api/hd/accounts")
+		var responseBody = mvc.perform(post("/hd/accounts")
 				.content(jackson.writeValueAsString(source))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -161,7 +161,7 @@ class StaffAccountControllerWebIntegrationTests {
 				.setFirstName("Hans123")
 				.setLastName("Huber123");
 
-		var response = mvc.perform(put("/api/hd/accounts/" + agent1.get().getId())
+		var response = mvc.perform(put("/hd/accounts/" + agent1.get().getId())
 				.content(jackson.writeValueAsString(dto))
 				.contentType(MediaType.APPLICATION_JSON)) // )
 				.andExpect(status().isBadRequest())
@@ -188,7 +188,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var password = "MyN3wAgentPassw0rD";
 		var newPassword = Map.of("password", password, "passwordConfirm", password);
 
-		mvc.perform(put("/api/hd/accounts/{id}/password", agent1.getId())
+		mvc.perform(put("/hd/accounts/{id}/password", agent1.getId())
 				.content(jackson.writeValueAsString(newPassword))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().is2xxSuccessful());
@@ -202,7 +202,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var password = "MyN3wAgentPassw0rD";
 		var newPassword = Map.of("password", password, "passwordConfirm", password);
 
-		mvc.perform(put("/api/hd/accounts/{id}/password", agent3.getId())
+		mvc.perform(put("/hd/accounts/{id}/password", agent3.getId())
 				.content(jackson.writeValueAsString(newPassword))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
@@ -216,7 +216,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var password = "MyN3wAgentPassw0rD";
 		var newPassword = Map.of("password", password, "passwordConfirm", "-not matching-");
 
-		var responseBody = mvc.perform(put("/api/hd/accounts/{id}/password", agent1.getId())
+		var responseBody = mvc.perform(put("/hd/accounts/{id}/password", agent1.getId())
 				.content(jackson.writeValueAsString(newPassword))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -237,7 +237,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var password = "MyN3wAgentPassw0rD";
 		var newPassword = Map.of("password", password, "passwordConfirm", password);
 
-		mvc.perform(put("/api/hd/accounts/{id}/password", UUID.randomUUID().toString())
+		mvc.perform(put("/hd/accounts/{id}/password", UUID.randomUUID().toString())
 				.content(jackson.writeValueAsString(newPassword))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());
@@ -251,7 +251,7 @@ class StaffAccountControllerWebIntegrationTests {
 		var password = "MyN3wAgentPassw0rD";
 		var newPassword = Map.of("password", password, "passwordConfirm", password);
 
-		mvc.perform(put("/api/hd/accounts/{id}/password", user1.getId())
+		mvc.perform(put("/hd/accounts/{id}/password", user1.getId())
 				.content(jackson.writeValueAsString(newPassword))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound());

--- a/backend/src/test/java/quarano/actions/web/AnomaliesControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/actions/web/AnomaliesControllerWebIntegrationTests.java
@@ -55,7 +55,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		var trackedCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON3_ID_DEP2)
 				.orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/actions/{id}", trackedCase.getId()))
+		var response = mvc.perform(get("/hd/actions/{id}", trackedCase.getId()))
 				.andExpect(status().isOk())
 				.andDo(documentAnomaly())
 				.andReturn().getResponse().getContentAsString();
@@ -74,7 +74,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		var trackedCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON4_ID_DEP2)
 				.orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/actions/{id}", trackedCase.getId()))
+		var response = mvc.perform(get("/hd/actions/{id}", trackedCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -96,7 +96,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		ActionsReviewed reviewed = new ActionsReviewed();
 		reviewed.setComment("Comment!");
 
-		var response = mvc.perform(put("/api/hd/actions/{id}/resolve", trackedCase.getId())
+		var response = mvc.perform(put("/hd/actions/{id}/resolve", trackedCase.getId())
 				.content(jackson.writeValueAsString(reviewed))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -114,7 +114,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 	@WithQuaranoUser("agent3")
 	void resolvesAnomaliesManuallyDoesNotWorkForSystemAnomalies() throws Exception {
 
-		var actionsResponse = mvc.perform(get("/api/hd/actions").accept("application/json"))
+		var actionsResponse = mvc.perform(get("/hd/actions").accept("application/json"))
 				.andExpect(status().isOk())
 				.andDo(documentAnomalies())
 				.andReturn().getResponse().getContentAsString();
@@ -125,7 +125,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		ActionsReviewed reviewed = new ActionsReviewed()
 				.setComment("Comment!");
 
-		var response = mvc.perform(put("/api/hd/actions/{id}/resolve", contactCaseId)
+		var response = mvc.perform(put("/hd/actions/{id}/resolve", contactCaseId)
 				.content(jackson.writeValueAsString(reviewed))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -151,13 +151,13 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		var trackedCase = cases.findById(TrackedCaseDataInitializer.TRACKED_CASE_SANDRA).orElseThrow();
 		var reviewed = new ActionsReviewed().setComment("Comment!");
 
-		mvc.perform(put("/api/hd/actions/{id}/resolve", trackedCase.getId())
+		mvc.perform(put("/hd/actions/{id}/resolve", trackedCase.getId())
 				.content(jackson.writeValueAsString(reviewed))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
-		var response = mvc.perform(get("/api/hd/actions"))
+		var response = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -178,7 +178,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 	void getActionsDoesNotReturnConcludedCases() throws Exception {
 
 		// get an active case with open actions
-		var actionsResponse = mvc.perform(get("/api/hd/actions").accept("application/json"))
+		var actionsResponse = mvc.perform(get("/hd/actions").accept("application/json"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -192,7 +192,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 				.orElseThrow();
 
 		// request list again
-		var result = mvc.perform(get("/api/hd/actions"))
+		var result = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -212,7 +212,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 				.filter(it -> it.originatesFrom(originCase))
 				.stream().findFirst().orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/actions")
+		var response = mvc.perform(get("/hd/actions")
 				.accept("application/hal+json"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();

--- a/backend/src/test/java/quarano/department/web/EnrollmentWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/EnrollmentWebIntegrationTests.java
@@ -282,7 +282,7 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 	@WithQuaranoUser("test5") // Nadine Ebert
 	void caseWithEnrollmentCompletedDoNotExposeNextLinkPointingToEnrollment() throws Exception {
 
-		var response = mvc.perform(get("/api/user/me"))
+		var response = mvc.perform(get("/user/me"))
 				.andReturn().getResponse().getContentAsString();
 
 		assertThat(discoverer.findLinkWithRel(IanaLinkRelations.NEXT, response)).isEmpty();
@@ -321,14 +321,14 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 	}
 
 	private String performRequestToGetEnrollementState() throws UnsupportedEncodingException, Exception {
-		String result = mvc.perform(get("/api/enrollment"))
+		String result = mvc.perform(get("/enrollment"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 		return result;
 	}
 
 	private String performRequestToGetQuestionnaire() throws UnsupportedEncodingException, Exception {
-		String result = mvc.perform(get("/api/enrollment/questionnaire"))
+		String result = mvc.perform(get("/enrollment/questionnaire"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 		return result;
@@ -348,7 +348,7 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 				.setSerializationInclusion(Include.NON_NULL)
 				.writeValueAsString(source);
 
-		var request = mvc.perform(put("/api/enrollment/details")
+		var request = mvc.perform(put("/enrollment/details")
 				.param("confirmed", "true")
 				.content(body)
 				.contentType(MediaType.APPLICATION_JSON));
@@ -382,7 +382,7 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 				.setSerializationInclusion(Include.NON_NULL)
 				.writeValueAsString(source);
 
-		var request = mvc.perform(put("/api/enrollment/details")
+		var request = mvc.perform(put("/enrollment/details")
 				.content(body)
 				.contentType(MediaType.APPLICATION_JSON));
 
@@ -395,7 +395,7 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 
 	private void submitQuestionnaireSuccessfully(QuestionnaireDto source) throws Exception {
 
-		mvc.perform(put("/api/enrollment/questionnaire")
+		mvc.perform(put("/enrollment/questionnaire")
 				.content(jackson.writeValueAsString(source))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -404,7 +404,7 @@ class EnrollmentWebIntegrationTests extends AbstractDocumentation {
 
 	private String submitQuestionnaireExpectBadRequest(QuestionnaireDto source) throws Exception {
 
-		return mvc.perform(put("/api/enrollment/questionnaire")
+		return mvc.perform(put("/enrollment/questionnaire")
 				.content(jackson.writeValueAsString(source))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())

--- a/backend/src/test/java/quarano/department/web/RegistrationWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/RegistrationWebIntegrationTests.java
@@ -67,7 +67,7 @@ class RegistrationWebIntegrationTests {
 				.build();
 
 		// when
-		var response = mvc.perform(post("/api/registration")
+		var response = mvc.perform(post("/registration")
 				.header("Origin", "*")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(registrationDto)))
@@ -150,7 +150,7 @@ class RegistrationWebIntegrationTests {
 		var harrietteCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON7_ID_DEP1)
 				.orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/cases/{id}/registration", harrietteCase.getId()))
+		var response = mvc.perform(get("/hd/cases/{id}/registration", harrietteCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getResponse()
@@ -168,7 +168,7 @@ class RegistrationWebIntegrationTests {
 		var harryCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON6_ID_DEP1)
 				.orElseThrow();
 
-		var response = mvc.perform(put("/api/hd/cases/{id}/registration", harryCase.getId()))
+		var response = mvc.perform(put("/hd/cases/{id}/registration", harryCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getResponse()
@@ -197,7 +197,7 @@ class RegistrationWebIntegrationTests {
 		var harryCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON6_ID_DEP1)
 				.orElseThrow();
 
-		var response = mvc.perform(put("/api/hd/cases/{id}/registration", harryCase.getId()))
+		var response = mvc.perform(put("/hd/cases/{id}/registration", harryCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getResponse()
@@ -216,7 +216,7 @@ class RegistrationWebIntegrationTests {
 		var harrietteCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON7_ID_DEP1)
 				.orElseThrow();
 
-		response = mvc.perform(put("/api/hd/cases/{id}/registration", harrietteCase.getId()))
+		response = mvc.perform(put("/hd/cases/{id}/registration", harrietteCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getResponse()
@@ -235,7 +235,7 @@ class RegistrationWebIntegrationTests {
 		var tanjaCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON1_ID_DEP1)
 				.orElseThrow();
 
-		response = mvc.perform(put("/api/hd/cases/{id}/registration", tanjaCase.getId()))
+		response = mvc.perform(put("/hd/cases/{id}/registration", tanjaCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn()
 				.getResponse()
@@ -267,7 +267,7 @@ class RegistrationWebIntegrationTests {
 				.build();
 
 		// when
-		var responseBody = mvc.perform(post("/api/registration")
+		var responseBody = mvc.perform(post("/registration")
 				.header("Origin", "*")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(registrationDto)))
@@ -362,7 +362,7 @@ class RegistrationWebIntegrationTests {
 		assertThat(person.getLocale()).isNotNull().isNotEqualTo(newLocale);
 
 		// when
-		mvc.perform(post("/api/registration")
+		mvc.perform(post("/registration")
 				.header("Origin", "*")
 				.locale(newLocale)
 				.contentType(MediaType.APPLICATION_JSON)
@@ -397,7 +397,7 @@ class RegistrationWebIntegrationTests {
 
 		// Initiate registration
 
-		mvc.perform(post("/api/registration")
+		mvc.perform(post("/registration")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(registrationDto)))
 				.andExpect(status().is2xxSuccessful())
@@ -408,7 +408,7 @@ class RegistrationWebIntegrationTests {
 
 		registrationDto.setUsername("someother");
 
-		var response = mvc.perform(post("/api/registration")
+		var response = mvc.perform(post("/registration")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(registrationDto)))
 				.andExpect(status().isBadRequest())
@@ -428,7 +428,7 @@ class RegistrationWebIntegrationTests {
 		var harryCase = cases.findByTrackedPerson(personId)
 				.orElseThrow();
 
-		mvc.perform(put("/api/hd/cases/{id}/registration", harryCase.getId()))
+		mvc.perform(put("/hd/cases/{id}/registration", harryCase.getId()))
 				.andExpect(status().isOk());
 
 		// Initial activation code
@@ -437,7 +437,7 @@ class RegistrationWebIntegrationTests {
 		assertThatCode(() -> {
 
 			// Re-start registration
-			var response = mvc.perform(put("/api/hd/cases/{id}/registration", harryCase.getId()))
+			var response = mvc.perform(put("/hd/cases/{id}/registration", harryCase.getId()))
 					.andExpect(status().isOk())
 					.andReturn().getResponse().getContentAsString();
 
@@ -456,7 +456,7 @@ class RegistrationWebIntegrationTests {
 
 	private void callUserMeAndCheckSuccess(String token, TrackedPerson person) throws Exception {
 
-		String resultDtoStr = mvc.perform(get("/api/user/me")
+		String resultDtoStr = mvc.perform(get("/user/me")
 				.header("Origin", "*")
 				.header("Authorization", "Bearer " + token)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -508,7 +508,7 @@ class RegistrationWebIntegrationTests {
 
 	private String expectFailedRegistration(RegistrationDto payload) throws Exception {
 
-		return mvc.perform(post("/api/registration")
+		return mvc.perform(post("/registration")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(payload)))
 				.andExpect(status().isBadRequest())

--- a/backend/src/test/java/quarano/department/web/TrackedCaseControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/TrackedCaseControllerWebIntegrationTests.java
@@ -124,7 +124,7 @@ class TrackedCaseControllerWebIntegrationTests {
 		LocalDate today = LocalDate.now();
 
 		// get the first case
-		var response = mvc.perform(get("/api/hd/cases")
+		var response = mvc.perform(get("/hd/cases")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
@@ -141,14 +141,14 @@ class TrackedCaseControllerWebIntegrationTests {
 		var payload = createMinimalIndexPayload().setQuarantineEndDate(quarantineEndDate)
 				.setQuarantineStartDate(quarantineStartDate);
 
-		mvc.perform(put("/api/hd/cases/{id}", trackedCaseId)
+		mvc.perform(put("/hd/cases/{id}", trackedCaseId)
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
 		// fetch cases again and check if quarantine start and end dates are shown correctly
-		var readResponseAfterUpdate = mvc.perform(get("/api/hd/cases")
+		var readResponseAfterUpdate = mvc.perform(get("/hd/cases")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
@@ -245,7 +245,7 @@ class TrackedCaseControllerWebIntegrationTests {
 				.setTestDate(LocalDate.now().minusDays(8))
 				.setInfected(true);
 
-		var response = expectBadRequest(HttpMethod.POST, "/api/hd/cases?type=contact", payload);
+		var response = expectBadRequest(HttpMethod.POST, "/hd/cases?type=contact", payload);
 
 		assertThat(response.read("$.testDate", String.class)).isNotNull();
 	}
@@ -262,7 +262,7 @@ class TrackedCaseControllerWebIntegrationTests {
 						!it.getKey().isBlank() ? "?".concat(it.getKey()) : ""),
 				test -> {
 
-					var baseUri = "/api/hd/cases";
+					var baseUri = "/hd/cases";
 					var uri = baseUri.concat(!test.getKey().isBlank() ? "?".concat(test.getKey()) : "");
 					var response = expectBadRequest(HttpMethod.POST, uri, new TrackedCaseDto());
 					var group = test.getValue() == Default.class ? null : test.getValue();
@@ -287,7 +287,7 @@ class TrackedCaseControllerWebIntegrationTests {
 				.setStreet("\\")
 				.setExtReferenceNumber("ADF !").setHouseNumber("\\");
 
-		var document = expectBadRequest(HttpMethod.POST, "/api/hd/cases", payload);
+		var document = expectBadRequest(HttpMethod.POST, "/hd/cases", payload);
 
 		var houseNumber = messages.getMessage("Pattern.houseNumber");
 		var firstName = messages.getMessage("Pattern.firstName");
@@ -312,7 +312,7 @@ class TrackedCaseControllerWebIntegrationTests {
 				.setEmail(null)
 				.setDateOfBirth(null);
 
-		var document = expectBadRequest(HttpMethod.PUT, "/api/hd/cases/" + trackedCase.getId(), payload);
+		var document = expectBadRequest(HttpMethod.PUT, "/hd/cases/" + trackedCase.getId(), payload);
 
 		assertThat(document.read("$.email", String.class)).isNotNull();
 	}
@@ -320,7 +320,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	@Test
 	void getAllCasesOrderedCorrectly() throws Exception {
 
-		var response = mvc.perform(get("/api/hd/cases")
+		var response = mvc.perform(get("/hd/cases")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
@@ -346,7 +346,7 @@ class TrackedCaseControllerWebIntegrationTests {
 		var payload = new CommentInput();
 		payload.setComment("Kommentar!");
 
-		var response = mvc.perform(post("/api/hd/cases/{id}/comments", trackedCase.getId())
+		var response = mvc.perform(post("/hd/cases/{id}/comments", trackedCase.getId())
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -401,7 +401,7 @@ class TrackedCaseControllerWebIntegrationTests {
 		var contactCase = createMinimalContactPayload();
 		contactCase.setEmail("");
 
-		mvc.perform(post("/api/hd/cases")
+		mvc.perform(post("/hd/cases")
 				.content(jackson.writeValueAsString(contactCase))
 				.contentType(MediaType.APPLICATION_JSON)
 				.param("type", "contact"))
@@ -509,7 +509,7 @@ class TrackedCaseControllerWebIntegrationTests {
 				.setFirstName("Max")
 				.setLastName("Mustermann");
 
-		var response = mvc.perform(put("/api/hd/cases/{id}", trackedCase.getId())
+		var response = mvc.perform(put("/hd/cases/{id}", trackedCase.getId())
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -526,7 +526,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		var trackingCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_SEC1_ID_DEP1).orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/cases/{id}", trackingCase.getId()))
+		var response = mvc.perform(get("/hd/cases/{id}", trackingCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -548,7 +548,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		var trackingCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_SEC1_ID_DEP1).orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/cases/{id}", trackingCase.getId()))
+		var response = mvc.perform(get("/hd/cases/{id}", trackingCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -588,7 +588,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		var trackingCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_SEC1_ID_DEP1).orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/cases/{id}", trackingCase.getId()))
+		var response = mvc.perform(get("/hd/cases/{id}", trackingCase.getId()))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -626,7 +626,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	@Test // CORE-252
 	void filtersCasesIfQueryGiven() throws Exception {
 
-		String response = mvc.perform(get("/api/hd/cases?q={query}", "ert"))
+		String response = mvc.perform(get("/hd/cases?q={query}", "ert"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -637,7 +637,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	@Test // CORE-252
 	void projectsCasesIfProjectionGiven() throws Exception {
 
-		String response = mvc.perform(get("/api/hd/cases?q={query}&projection={projection}", "ert", "select"))
+		String response = mvc.perform(get("/hd/cases?q={query}&projection={projection}", "ert", "select"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -662,9 +662,9 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		contactCase.addOriginCase(originCase);
 
-		TestUtils.fakeRequest(HttpMethod.GET, "/api/hd/cases", mvc.getDispatcherServlet().getWebApplicationContext());
+		TestUtils.fakeRequest(HttpMethod.GET, "/hd/cases", mvc.getDispatcherServlet().getWebApplicationContext());
 
-		var response = mvc.perform(put("/api/hd/cases/{id}", contactCase.getId())
+		var response = mvc.perform(put("/hd/cases/{id}", contactCase.getId())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jackson.writeValueAsString(representations.toInputRepresentation(contactCase))))
 				.andExpect(status().isOk())
@@ -685,7 +685,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	@Test // CORE-346
 	void returnsOnlyIndexCasesIfFiltered() throws Exception {
 
-		var result = mvc.perform(get("/api/hd/cases")
+		var result = mvc.perform(get("/hd/cases")
 				.contentType(MediaType.APPLICATION_JSON)
 				.param("type", "index"))
 				.andExpect(status().isOk())
@@ -701,7 +701,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	@WithQuaranoUser("admin")
 	void exposesNumberOfOpenAnomalies() throws Exception {
 
-		var result = mvc.perform(get("/api/hd/cases/{id}", TrackedCaseDataInitializer.TRACKED_CASE_GUSTAV)
+		var result = mvc.perform(get("/hd/cases/{id}", TrackedCaseDataInitializer.TRACKED_CASE_GUSTAV)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
@@ -721,7 +721,7 @@ class TrackedCaseControllerWebIntegrationTests {
 				.filter(it -> it.originatesFrom(originCase))
 				.stream().findFirst().orElseThrow();
 
-		var response = mvc.perform(get("/api/hd/cases")
+		var response = mvc.perform(get("/hd/cases")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
@@ -777,7 +777,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		try {
 
-			return mvc.perform(post("/api/hd/cases")
+			return mvc.perform(post("/hd/cases")
 					.param("type", type == CaseType.INDEX ? "index" : "contact")
 					.content(jackson.writeValueAsString(payload))
 					.contentType(MediaType.APPLICATION_JSON))
@@ -794,7 +794,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		try {
 
-			return mvc.perform(post("/api/hd/cases")
+			return mvc.perform(post("/hd/cases")
 					.param("type", type == CaseType.INDEX ? "index" : "contact")
 					.content(jackson.writeValueAsString(payload))
 					.contentType(MediaType.APPLICATION_JSON))
@@ -816,7 +816,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		try {
 
-			return mvc.perform(put("/api/hd/cases/{id}", caseId)
+			return mvc.perform(put("/hd/cases/{id}", caseId)
 					.param("type", type == CaseType.INDEX ? "index" : "contact")
 					.content(jackson.writeValueAsString(payload))
 					.contentType(MediaType.APPLICATION_JSON))
@@ -831,7 +831,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	private MockHttpServletResponse issueToIndexCaseTransformation(TrackedCaseDto payload, TrackedCaseIdentifier id)
 			throws Exception, JsonProcessingException {
 
-		return mvc.perform(put("/api/hd/cases/{id}", id)
+		return mvc.perform(put("/hd/cases/{id}", id)
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -841,7 +841,7 @@ class TrackedCaseControllerWebIntegrationTests {
 	private MockHttpServletResponse expectBadRequestOnTransformationCall(TrackedCaseDto payload,
 			TrackedCaseIdentifier caseId) throws Exception, JsonProcessingException {
 
-		return mvc.perform(put("/api/hd/cases/{id}", caseId)
+		return mvc.perform(put("/hd/cases/{id}", caseId)
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -855,7 +855,7 @@ class TrackedCaseControllerWebIntegrationTests {
 
 		try {
 
-			return mvc.perform(put("/api/hd/cases/{caseId}", trackedCase.getId())
+			return mvc.perform(put("/hd/cases/{caseId}", trackedCase.getId())
 					.content(jackson.writeValueAsString(payload))
 					.contentType(MediaType.APPLICATION_JSON))
 					.andExpect(status().isBadRequest())

--- a/backend/src/test/java/quarano/department/web/TrackedCaseRepresentationIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/web/TrackedCaseRepresentationIntegrationTests.java
@@ -59,7 +59,7 @@ class TrackedCaseRepresentationIntegrationTests {
 	@Test
 	void exposesCaseTypeLabelOnSummary() {
 
-		TestUtils.fakeRequest(HttpMethod.GET, "/api/hd/cases", context);
+		TestUtils.fakeRequest(HttpMethod.GET, "/hd/cases", context);
 
 		var contactCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON1_ID_DEP1)
 				.orElseThrow();
@@ -88,7 +88,7 @@ class TrackedCaseRepresentationIntegrationTests {
 	@Test // CORE-252
 	void doesNotSerializeOriginCasesInMainBody() throws Exception {
 
-		TestUtils.fakeRequest(HttpMethod.GET, "/api/hd/cases", context);
+		TestUtils.fakeRequest(HttpMethod.GET, "/hd/cases", context);
 
 		var contactCase = cases.findByTrackedPerson(TrackedPersonDataInitializer.VALID_TRACKED_PERSON1_ID_DEP1)
 				.orElseThrow();

--- a/backend/src/test/java/quarano/diary/web/DiaryControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/diary/web/DiaryControllerWebIntegrationTests.java
@@ -39,7 +39,7 @@ class DiaryControllerWebIntegrationTests {
 		var payload = new DiaryEntryInput(slot)
 				.setBodyTemperature(42.0f);
 
-		var response = mvc.perform(post("/api/diary")
+		var response = mvc.perform(post("/diary")
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated())
@@ -69,7 +69,7 @@ class DiaryControllerWebIntegrationTests {
 		DiaryEntryInput payload = new DiaryEntryInput(slot)
 				.setBodyTemperature(42.0f);
 
-		String response = mvc.perform(put("/api/diary/{identifier}", entry.getId())
+		String response = mvc.perform(put("/diary/{identifier}", entry.getId())
 				.content(jackson.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())

--- a/backend/src/test/java/quarano/masterdata/web/FrontendTextControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/masterdata/web/FrontendTextControllerWebIntegrationTests.java
@@ -25,7 +25,7 @@ class FrontendTextControllerWebIntegrationTests extends AbstractDocumentation {
 	@Test
 	void getAllTexts() throws Exception {
 
-		var result = mvc.perform(get("/api/frontendtexts")
+		var result = mvc.perform(get("/frontendtexts")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andDo(documentGetFrontendTexts())
 				.andExpect(status().is2xxSuccessful())

--- a/backend/src/test/java/quarano/masterdata/web/SymptomControllerWebIntegrationTest.java
+++ b/backend/src/test/java/quarano/masterdata/web/SymptomControllerWebIntegrationTest.java
@@ -44,7 +44,7 @@ class SymptomControllerWebIntegrationTest {
 
 	private DocumentContext getSymptoms(Locale locale) throws Exception {
 
-		var response = mvc.perform(get("/api/symptoms")
+		var response = mvc.perform(get("/symptoms")
 				.contentType(MediaType.APPLICATION_JSON)
 				.locale(locale))
 				.andReturn().getResponse().getContentAsString();

--- a/backend/src/test/java/quarano/security/web/AuthenticationControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/security/web/AuthenticationControllerWebIntegrationTests.java
@@ -55,7 +55,7 @@ class AuthenticationControllerWebIntegrationTests extends AbstractDocumentation 
 
 		cases.save(siggisCase);
 
-		mvc.perform(post("/api/login")
+		mvc.perform(post("/login")
 				.content(jackson.writeValueAsString(new AuthenticationRequest("secUser1", "secur1tyTest!")))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isForbidden());
@@ -85,7 +85,7 @@ class AuthenticationControllerWebIntegrationTests extends AbstractDocumentation 
 		var account = accounts.changePassword(password, accounts.findByUsername("agent4").orElseThrow());
 
 		// When logging in
-		var result = mvc.perform(post("/api/login")
+		var result = mvc.perform(post("/login")
 				.content(jackson.writeValueAsString(new AuthenticationRequest(account.getUsername(), "test")))
 				.contentType(MediaType.APPLICATION_JSON))
 
@@ -149,7 +149,7 @@ class AuthenticationControllerWebIntegrationTests extends AbstractDocumentation 
 				.map(cases::save)
 				.orElseThrow();
 
-		mvc.perform(post("/api/login")
+		mvc.perform(post("/login")
 				.locale(trackedCase.getTrackedPerson().getLocale())
 				.content(jackson.writeValueAsString(new AuthenticationRequest("DemoAccount", "DemoPassword"))))
 				.andExpect(status().isForbidden());
@@ -168,7 +168,7 @@ class AuthenticationControllerWebIntegrationTests extends AbstractDocumentation 
 
 	private void assertSuccessfulLogin(String username, String password, Locale locale) throws Exception {
 
-		mvc.perform(post("/api/login")
+		mvc.perform(post("/login")
 				.locale(locale)
 				.content(jackson.writeValueAsString(new AuthenticationRequest(username, password)))
 				.contentType(MediaType.APPLICATION_JSON))

--- a/backend/src/test/java/quarano/security/web/SecurityWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/security/web/SecurityWebIntegrationTests.java
@@ -23,7 +23,7 @@ public class SecurityWebIntegrationTests {
 	@WithQuaranoUser("admin")
 	void staffAdminCanAccessStaffResources() throws Exception {
 
-		mvc.perform(get("/api/hd/cases"))
+		mvc.perform(get("/hd/cases"))
 				.andExpect(status().isOk());
 	}
 }

--- a/backend/src/test/java/quarano/tracking/web/ContactPersonControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/tracking/web/ContactPersonControllerWebIntegrationTests.java
@@ -46,7 +46,7 @@ class ContactPersonControllerWebIntegrationTests {
 		payload.setEmail("test@testtest.de");
 		payload.setMobilePhone("0123910");
 
-		String response = mvc.perform(post("/api/contacts")
+		String response = mvc.perform(post("/contacts")
 				.content(mapper.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isCreated())
@@ -66,7 +66,7 @@ class ContactPersonControllerWebIntegrationTests {
 
 		var payload = new ContactPersonDto();
 
-		String response = mvc.perform(post("/api/contacts")
+		String response = mvc.perform(post("/contacts")
 				.content(mapper.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -91,7 +91,7 @@ class ContactPersonControllerWebIntegrationTests {
 		.setStreet("\\")
 		.setHouseNumber("\\");
 
-		String response = mvc.perform(post("/api/contacts")
+		String response = mvc.perform(post("/contacts")
 				.content(mapper.writeValueAsString(payload))
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isBadRequest())
@@ -128,7 +128,7 @@ class ContactPersonControllerWebIntegrationTests {
 					var payload = JsonPath.parse(mapper.writeValueAsString(new ContactPersonDto())).set("$." + entry.getKey(),
 							entry.getValue());
 
-					String response = mvc.perform(post("/api/contacts")
+					String response = mvc.perform(post("/contacts")
 							.content(payload.jsonString())
 							.contentType(MediaType.APPLICATION_JSON))
 							.andExpect(status().isCreated())

--- a/backend/src/test/java/quarano/user/LocaleConfigurationTests.java
+++ b/backend/src/test/java/quarano/user/LocaleConfigurationTests.java
@@ -32,7 +32,7 @@ import com.jayway.jsonpath.JsonPath;
 @RequiredArgsConstructor
 public class LocaleConfigurationTests {
 
-	static final String ME = "/api/user/me";
+	static final String ME = "/user/me";
 
 	static final String DEFAULT_LOCALE = "de-DE";
 
@@ -143,7 +143,7 @@ public class LocaleConfigurationTests {
 
 	private MockHttpServletResponse performWrongPasswordChange(Locale locale) throws Exception {
 
-		return mvc.perform(put("/api/user/me/password")
+		return mvc.perform(put("/user/me/password")
 				.header("Origin", "*")
 				.locale(locale)
 				.contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/user/web/UserControllerWebIntegrationTests.java
@@ -73,7 +73,7 @@ class UserControllerWebIntegrationTests extends AbstractDocumentation {
 
 	private String performGet(String token) throws Exception {
 		// check if token is valid for authentication
-		String resultDtoStr = mvc.perform(get("/api/user/me")
+		String resultDtoStr = mvc.perform(get("/user/me")
 				.header("Origin", "*")
 				.header("Authorization", "Bearer " + token)
 				.contentType(MediaType.APPLICATION_JSON))
@@ -110,7 +110,7 @@ class UserControllerWebIntegrationTests extends AbstractDocumentation {
 		var newPassword = "newPassword";
 		var payload = new UserController.NewPassword(PASSWORD, newPassword, newPassword);
 
-		mvc.perform(put("/api/user/me/password")
+		mvc.perform(put("/user/me/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(payload))
 				.header("Authorization", "Bearer " + token))
@@ -130,7 +130,7 @@ class UserControllerWebIntegrationTests extends AbstractDocumentation {
 		var newPassword = "newPassword";
 		var payload = new UserController.NewPassword(password, newPassword, newPassword);
 
-		mvc.perform(put("/api/user/me/password")
+		mvc.perform(put("/user/me/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(payload))
 				.header("Authorization", "Bearer " + token))
@@ -205,7 +205,7 @@ class UserControllerWebIntegrationTests extends AbstractDocumentation {
 
 		var token = login(USERNAME, PASSWORD);
 
-		return mvc.perform(put("/api/user/me/password")
+		return mvc.perform(put("/user/me/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(mapper.writeValueAsString(payload))
 				.header("Authorization", "Bearer " + token));

--- a/frontend/apps/quarano-frontend-e2e/src/fixtures/get-api-hd-cases.json
+++ b/frontend/apps/quarano-frontend-e2e/src/fixtures/get-api-hd-cases.json
@@ -19,7 +19,7 @@
         "status": "in Nachverfolgung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/03ea6953-f06c-418a-975c-bb2ff79c1ff3"
+            "href": "http://localhost:8080/hd/cases/03ea6953-f06c-418a-975c-bb2ff79c1ff3"
           }
         }
       },
@@ -41,7 +41,7 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/8c7970e9-c5ac-49d7-b80f-eda7cc1bf4d6"
+            "href": "http://localhost:8080/hd/cases/8c7970e9-c5ac-49d7-b80f-eda7cc1bf4d6"
           }
         }
       },
@@ -63,7 +63,7 @@
         "status": "angelegt",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/aef1346c-c8b1-48a8-ae57-12937c4a6a3b"
+            "href": "http://localhost:8080/hd/cases/aef1346c-c8b1-48a8-ae57-12937c4a6a3b"
           }
         }
       },
@@ -85,7 +85,7 @@
         "status": "in Nachverfolgung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/8ea1a457-3ba2-4319-a393-3d1379ab66cb"
+            "href": "http://localhost:8080/hd/cases/8ea1a457-3ba2-4319-a393-3d1379ab66cb"
           }
         }
       },
@@ -104,13 +104,13 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f"
+            "href": "http://localhost:8080/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f"
           },
           "start-tracking": {
-            "href": "http://localhost:8080/api/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f/registration"
+            "href": "http://localhost:8080/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f/registration"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f/registration"
+            "href": "http://localhost:8080/hd/cases/77badc2c-e71f-452f-addb-87d43962a58f/registration"
           }
         }
       },
@@ -132,13 +132,13 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05"
+            "href": "http://localhost:8080/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05"
           },
           "start-tracking": {
-            "href": "http://localhost:8080/api/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05/registration"
+            "href": "http://localhost:8080/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05/registration"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05/registration"
+            "href": "http://localhost:8080/hd/cases/2def05c0-ffa5-456f-b359-90ef7f88db05/registration"
           }
         }
       },
@@ -160,13 +160,13 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9"
+            "href": "http://localhost:8080/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9"
           },
           "start-tracking": {
-            "href": "http://localhost:8080/api/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9/registration"
+            "href": "http://localhost:8080/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9/registration"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9/registration"
+            "href": "http://localhost:8080/hd/cases/5bffd8ad-6ad5-405f-a31c-6373f621e4d9/registration"
           }
         }
       },
@@ -188,13 +188,13 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f"
+            "href": "http://localhost:8080/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f"
           },
           "start-tracking": {
-            "href": "http://localhost:8080/api/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f/registration"
+            "href": "http://localhost:8080/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f/registration"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f/registration"
+            "href": "http://localhost:8080/hd/cases/2fed21be-5638-4fe6-ac9c-2292e482a24f/registration"
           }
         }
       },
@@ -216,10 +216,10 @@
         "status": "in Nachverfolgung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/01d8b3bd-041e-4493-b491-42f9bf40323d"
+            "href": "http://localhost:8080/hd/cases/01d8b3bd-041e-4493-b491-42f9bf40323d"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/01d8b3bd-041e-4493-b491-42f9bf40323d/registration"
+            "href": "http://localhost:8080/hd/cases/01d8b3bd-041e-4493-b491-42f9bf40323d/registration"
           }
         }
       },
@@ -241,10 +241,10 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/d73077aa-638f-4876-90f7-24793c7d9538"
+            "href": "http://localhost:8080/hd/cases/d73077aa-638f-4876-90f7-24793c7d9538"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/d73077aa-638f-4876-90f7-24793c7d9538/registration"
+            "href": "http://localhost:8080/hd/cases/d73077aa-638f-4876-90f7-24793c7d9538/registration"
           }
         }
       },
@@ -266,10 +266,10 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/a7912643-55d9-4a1c-a7d2-1b8eec8aaffe"
+            "href": "http://localhost:8080/hd/cases/a7912643-55d9-4a1c-a7d2-1b8eec8aaffe"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/a7912643-55d9-4a1c-a7d2-1b8eec8aaffe/registration"
+            "href": "http://localhost:8080/hd/cases/a7912643-55d9-4a1c-a7d2-1b8eec8aaffe/registration"
           }
         }
       },
@@ -291,13 +291,13 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b"
+            "href": "http://localhost:8080/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b"
           },
           "start-tracking": {
-            "href": "http://localhost:8080/api/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b/registration"
+            "href": "http://localhost:8080/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b/registration"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b/registration"
+            "href": "http://localhost:8080/hd/cases/91fc1ae4-2f86-4313-8750-ef4b7b87b15b/registration"
           }
         }
       },
@@ -319,10 +319,10 @@
         "status": "in Registrierung",
         "_links": {
           "conclude": {
-            "href": "http://localhost:8080/api/hd/cases/e781dd11-a3a5-403c-96b2-f20b18e559ed"
+            "href": "http://localhost:8080/hd/cases/e781dd11-a3a5-403c-96b2-f20b18e559ed"
           },
           "renew": {
-            "href": "http://localhost:8080/api/hd/cases/e781dd11-a3a5-403c-96b2-f20b18e559ed/registration"
+            "href": "http://localhost:8080/hd/cases/e781dd11-a3a5-403c-96b2-f20b18e559ed/registration"
           }
         }
       }

--- a/frontend/apps/quarano-frontend-e2e/src/integration/client/diary.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/client/diary.spec.ts
@@ -4,7 +4,7 @@ describe('Adding new symptom to symptom diary', () => {
   beforeEach(() => {
     cy.loginClient();
     cy.server();
-    cy.route('POST', '/api/diary').as('diary');
+    cy.route('POST', '/diary').as('diary');
   });
 
   it('not possible, when no body temperature is selected.', () => {

--- a/frontend/apps/quarano-frontend-e2e/src/integration/client/enrollment.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/client/enrollment.spec.ts
@@ -3,9 +3,9 @@
 describe('enrollment happy path', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('POST', '/api/enrollment/completion?withoutEncounters=true').as('completeenrollment');
-    cy.route('PUT', '/api/enrollment/questionnaire').as('updatequestionnaire');
-    cy.route('PUT', '/api/enrollment/details').as('updatepersonaldetails');
+    cy.route('POST', '/enrollment/completion?withoutEncounters=true').as('completeenrollment');
+    cy.route('PUT', '/enrollment/questionnaire').as('updatequestionnaire');
+    cy.route('PUT', '/enrollment/details').as('updatepersonaldetails');
 
     cy.loginNotEnrolledClient();
   });
@@ -58,8 +58,8 @@ describe('enrollment happy path', () => {
 describe('enrollment external zip code', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('PUT', '/api/enrollment/details?confirmed=true').as('updatepersonaldetailszipcodeconfirm');
-    cy.route('PUT', '/api/enrollment/details').as('updatepersonaldetails');
+    cy.route('PUT', '/enrollment/details?confirmed=true').as('updatepersonaldetailszipcodeconfirm');
+    cy.route('PUT', '/enrollment/details').as('updatepersonaldetails');
 
     cy.loginNotEnrolledClient2();
   });

--- a/frontend/apps/quarano-frontend-e2e/src/integration/general/static-pages.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/general/static-pages.spec.ts
@@ -1,7 +1,7 @@
 describe('static pages', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/frontendtexts').as('frontendtexts');
+    cy.route('GET', '/frontendtexts').as('frontendtexts');
     cy.visit('/');
   });
 

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/account-administration/new.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/account-administration/new.spec.ts
@@ -3,7 +3,7 @@
 describe('new account', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('POST', '/api/hd/accounts').as('createaccount');
+    cy.route('POST', '/hd/accounts').as('createaccount');
 
     cy.loginAdmin();
 
@@ -338,7 +338,7 @@ describe('new account', () => {
 describe('login with new account', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('PUT', '/api/user/me/password').as('changepassword');
+    cy.route('PUT', '/user/me/password').as('changepassword');
   });
 
   it('login with new account should open change password dialog', () => {

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/case-detail/new.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/case-detail/new.spec.ts
@@ -4,8 +4,8 @@ import { DateFunctions } from '@qro/shared/util-date';
 describe('new case', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('POST', '/api/hd/cases').as('createcase');
-    cy.route('PUT', '/api/hd/cases').as('updatecase');
+    cy.route('POST', '/hd/cases').as('createcase');
+    cy.route('PUT', '/hd/cases').as('updatecase');
 
     cy.loginAgent();
 

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/action-list.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/action-list.spec.ts
@@ -3,7 +3,7 @@
 describe('health-department contact cases action-list', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/hd/actions' /*, 'fixture:get-api-hd-cases.json'*/).as('allactions');
+    cy.route('GET', '/hd/actions' /*, 'fixture:get-api-hd-cases.json'*/).as('allactions');
 
     cy.loginAgent();
     cy.get('[data-cy="contact-cases"]').click();

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/case-list.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/case-list.spec.ts
@@ -3,7 +3,7 @@
 describe('health-department contact cases case-list', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/hd/cases').as('allcases');
+    cy.route('GET', '/hd/cases').as('allcases');
 
     cy.loginAgent();
     cy.get('[data-cy="contact-cases"]').click();

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/contact-cases.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/contact-cases/contact-cases.spec.ts
@@ -3,8 +3,8 @@
 describe('health-department contact cases', () => {
   beforeEach(() => {
     cy.loginAgent();
-    cy.route('POST', 'api/hd/cases/?type=contact').as('newContact');
-    cy.route('PUT', 'api/hd/cases/*').as('updateIndexCase');
+    cy.route('POST', '/hd/cases/?type=contact').as('newContact');
+    cy.route('PUT', '/hd/cases/*').as('updateIndexCase');
   });
 
   describe('converting to index case ', () => {

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/header.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/header.spec.ts
@@ -1,7 +1,7 @@
 describe('health-department top navigation', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/user/me').as('me');
+    cy.route('GET', '/user/me').as('me');
 
     cy.loginAgent();
   });

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/index-cases/action-list.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/index-cases/action-list.spec.ts
@@ -3,7 +3,7 @@
 describe('health-department index cases action-list', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/hd/actions').as('allactions');
+    cy.route('GET', '/hd/actions').as('allactions');
 
     cy.loginAgent();
     cy.get('[data-cy="action-list"]').should('exist');

--- a/frontend/apps/quarano-frontend-e2e/src/integration/health-department/index-cases/case-list.spec.ts
+++ b/frontend/apps/quarano-frontend-e2e/src/integration/health-department/index-cases/case-list.spec.ts
@@ -3,8 +3,8 @@
 describe('health-department index cases case-list', () => {
   beforeEach(() => {
     cy.server();
-    cy.route('GET', '/api/hd/cases').as('allcases');
-    cy.route('PUT', '/api/hd/cases/*').as('savedetails');
+    cy.route('GET', '/hd/cases').as('allcases');
+    cy.route('PUT', '/hd/cases/*').as('savedetails');
 
     cy.loginAgent();
   });

--- a/frontend/libs/administration/domain/src/lib/data-access/account.service.ts
+++ b/frontend/libs/administration/domain/src/lib/data-access/account.service.ts
@@ -12,23 +12,23 @@ export class AccountService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   getAccountList(): Observable<AccountListDto> {
-    return this.httpClient.get<any>(`${this.apiUrl}/api/hd/accounts`).pipe(
+    return this.httpClient.get<any>(`${this.apiUrl}/hd/accounts`).pipe(
       shareReplay(),
       map((result) => result._embedded)
     );
   }
 
   getAccountDetail(id: string): Observable<AccountDto> {
-    return this.httpClient.get<AccountDto>(`${this.apiUrl}/api/hd/accounts/${id}`).pipe(shareReplay());
+    return this.httpClient.get<AccountDto>(`${this.apiUrl}/hd/accounts/${id}`).pipe(shareReplay());
   }
 
   createAccount(account: AccountDto): Observable<AccountDto> {
-    return this.httpClient.post<AccountDto>(`${this.apiUrl}/api/hd/accounts`, account).pipe(shareReplay());
+    return this.httpClient.post<AccountDto>(`${this.apiUrl}/hd/accounts`, account).pipe(shareReplay());
   }
 
   editAccount(account: AccountDto): Observable<AccountDto> {
     return this.httpClient
-      .put<AccountDto>(`${this.apiUrl}/api/hd/accounts/${account.accountId}`, account)
+      .put<AccountDto>(`${this.apiUrl}/hd/accounts/${account.accountId}`, account)
       .pipe(shareReplay());
   }
 }

--- a/frontend/libs/auth/domain/src/lib/data-access/auth.service.ts
+++ b/frontend/libs/auth/domain/src/lib/data-access/auth.service.ts
@@ -13,11 +13,11 @@ export class AuthService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   changePassword(dto: ChangePasswordDto) {
-    return this.httpClient.put(`${this.apiUrl}/api/user/me/password`, dto).pipe(shareReplay());
+    return this.httpClient.put(`${this.apiUrl}/user/me/password`, dto).pipe(shareReplay());
   }
 
   checkUsername(username: string): Observable<any> {
-    return this.httpClient.get(`${this.apiUrl}/api/registration/checkusername/${username}`).pipe(shareReplay());
+    return this.httpClient.get(`${this.apiUrl}/registration/checkusername/${username}`).pipe(shareReplay());
   }
 
   login(username: string, password: string): Observable<any> {

--- a/frontend/libs/auth/domain/src/lib/store/auth.effects.ts
+++ b/frontend/libs/auth/domain/src/lib/store/auth.effects.ts
@@ -22,7 +22,7 @@ export class AuthEffects {
       ofType(AuthActions.login),
       switchMap((action) =>
         this.httpClient
-          .get<UserDto>(`${this.apiUrl}/api/user/me`, { observe: 'response' })
+          .get<UserDto>(`${this.apiUrl}/user/me`, { observe: 'response' })
           .pipe(shareReplay())
       ),
       withLatestFrom(this.store.pipe(select(LanguageSelectors.supportedLanguages))),

--- a/frontend/libs/client/domain/src/lib/data-access/client.service.ts
+++ b/frontend/libs/client/domain/src/lib/data-access/client.service.ts
@@ -17,11 +17,11 @@ export class ClientService {
   ) {}
 
   getPersonalDetails(): Observable<ClientDto> {
-    return this.httpClient.get<ClientDto>(`${this.apiUrl}/api/enrollment/details`).pipe(shareReplay());
+    return this.httpClient.get<ClientDto>(`${this.apiUrl}/enrollment/details`).pipe(shareReplay());
   }
 
   updatePersonalDetails(client: ClientDto, confirmedZipCode: boolean = false): Observable<any> {
-    let url = `${this.apiUrl}/api/enrollment/details`;
+    let url = `${this.apiUrl}/enrollment/details`;
     if (confirmedZipCode) {
       url += '?confirmed=true';
     }

--- a/frontend/libs/client/domain/src/lib/data-access/contact-person.service.ts
+++ b/frontend/libs/client/domain/src/lib/data-access/contact-person.service.ts
@@ -12,18 +12,18 @@ export class ContactPersonService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   getContactPersons(): Observable<ContactPersonDto[]> {
-    return this.httpClient.get<ContactPersonDto[]>(`${this.apiUrl}/api/contacts`).pipe(shareReplay());
+    return this.httpClient.get<ContactPersonDto[]>(`${this.apiUrl}/contacts`).pipe(shareReplay());
   }
 
   getContactPerson(id: string): Observable<ContactPersonDto> {
-    return this.httpClient.get<ContactPersonDto>(`${this.apiUrl}/api/contacts/${id}`).pipe(shareReplay());
+    return this.httpClient.get<ContactPersonDto>(`${this.apiUrl}/contacts/${id}`).pipe(shareReplay());
   }
 
   createContactPerson(contactPerson: ContactPersonModifyDto): Observable<ContactPersonDto> {
-    return this.httpClient.post<ContactPersonDto>(`${this.apiUrl}/api/contacts`, contactPerson).pipe(shareReplay());
+    return this.httpClient.post<ContactPersonDto>(`${this.apiUrl}/contacts`, contactPerson).pipe(shareReplay());
   }
 
   modifyContactPerson(contactPerson: ContactPersonModifyDto, id: string) {
-    return this.httpClient.put(`${this.apiUrl}/api/contacts/${id}`, contactPerson).pipe(shareReplay());
+    return this.httpClient.put(`${this.apiUrl}/contacts/${id}`, contactPerson).pipe(shareReplay());
   }
 }

--- a/frontend/libs/client/domain/src/lib/data-access/diary.service.ts
+++ b/frontend/libs/client/domain/src/lib/data-access/diary.service.ts
@@ -12,7 +12,7 @@ export class DiaryService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   getDiaryEntry(id: string): Observable<DiaryEntryDto> {
-    return this.httpClient.get<DiaryEntryDto>(`${this.apiUrl}/api/diary/${id}`).pipe(
+    return this.httpClient.get<DiaryEntryDto>(`${this.apiUrl}/diary/${id}`).pipe(
       shareReplay(),
       map((entry) => {
         entry.characteristicSymptoms = entry.symptoms.filter((s) => s.characteristic);
@@ -24,11 +24,11 @@ export class DiaryService {
   }
 
   getDiary(): Observable<DiaryDto> {
-    return this.httpClient.get<DiaryDto>(`${this.apiUrl}/api/diary`).pipe(shareReplay());
+    return this.httpClient.get<DiaryDto>(`${this.apiUrl}/diary`).pipe(shareReplay());
   }
 
   createDiaryEntry(diaryEntry: DiaryEntryModifyDto): Observable<DiaryEntryDto> {
-    return this.httpClient.post<DiaryEntryDto>(`${this.apiUrl}/api/diary`, diaryEntry).pipe(
+    return this.httpClient.post<DiaryEntryDto>(`${this.apiUrl}/diary`, diaryEntry).pipe(
       shareReplay(),
       map((entry) => {
         entry.date = this.getDate(entry.date);
@@ -38,7 +38,7 @@ export class DiaryService {
   }
 
   modifyDiaryEntry(diaryEntry: DiaryEntryModifyDto) {
-    return this.httpClient.put(`${this.apiUrl}/api/diary/${diaryEntry.id}`, diaryEntry).pipe(shareReplay());
+    return this.httpClient.put(`${this.apiUrl}/diary/${diaryEntry.id}`, diaryEntry).pipe(shareReplay());
   }
 
   private getDate(date: Date): Date {

--- a/frontend/libs/client/domain/src/lib/data-access/enrollment.service.ts
+++ b/frontend/libs/client/domain/src/lib/data-access/enrollment.service.ts
@@ -13,7 +13,7 @@ import { EncounterEntry, EncountersDto, EncounterDto, EncounterCreateDto } from 
   providedIn: 'root',
 })
 export class EnrollmentService {
-  private baseUrl = `${this.apiUrl}/api`;
+  private baseUrl = `${this.apiUrl}`;
 
   constructor(
     private httpClient: HttpClient,

--- a/frontend/libs/client/domain/src/lib/store/client.effects.ts
+++ b/frontend/libs/client/domain/src/lib/store/client.effects.ts
@@ -9,7 +9,7 @@ import { EnrollmentStatusDto } from '../model/enrollment-status';
 @Injectable()
 export class ClientEffects {
   constructor(private actions$: Actions, private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
-  private baseUrl = `${this.apiUrl}/api`;
+  private baseUrl = `${this.apiUrl}`;
 
   loadEnrollmentStatus$ = createEffect(() =>
     this.actions$.pipe(

--- a/frontend/libs/health-department/domain/src/lib/data-access/case-data.service.ts
+++ b/frontend/libs/health-department/domain/src/lib/data-access/case-data.service.ts
@@ -11,7 +11,7 @@ import { Update } from '@ngrx/entity';
 @Injectable()
 export class CaseDataService extends DefaultDataService<CaseDto> {
   constructor(http: HttpClient, httpUrlGenerator: HttpUrlGenerator, @Inject(API_URL) private apiUrl: string) {
-    super(CASE_FEATURE_KEY, http, httpUrlGenerator, { root: `${apiUrl}/api/hd` });
+    super(CASE_FEATURE_KEY, http, httpUrlGenerator, { root: `${apiUrl}/hd` });
   }
 
   getAll(): Observable<CaseDto[]> {

--- a/frontend/libs/health-department/domain/src/lib/data-access/contact-case.service.ts
+++ b/frontend/libs/health-department/domain/src/lib/data-access/contact-case.service.ts
@@ -13,7 +13,7 @@ export class ContactCaseService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   getActionList(): Observable<ActionListItemDto[]> {
-    return this.httpClient.get<any>(`${this.apiUrl}/api/hd/actions`).pipe(
+    return this.httpClient.get<any>(`${this.apiUrl}/hd/actions`).pipe(
       shareReplay(),
       map((result) => {
         if (result?._embedded?.actions) {

--- a/frontend/libs/health-department/domain/src/lib/data-access/health-department.service.ts
+++ b/frontend/libs/health-department/domain/src/lib/data-access/health-department.service.ts
@@ -18,25 +18,23 @@ export class HealthDepartmentService {
   }
 
   createCase(caseDetail: CaseDto, type: CaseType): Observable<CaseDto> {
-    return this.httpClient.post<CaseDto>(`${this.apiUrl}/api/hd/cases?type=${type}`, caseDetail).pipe(shareReplay());
+    return this.httpClient.post<CaseDto>(`${this.apiUrl}/hd/cases?type=${type}`, caseDetail).pipe(shareReplay());
   }
 
   updateCase(caseDetail: CaseDto): Observable<CaseDto> {
-    return this.httpClient
-      .put<CaseDto>(`${this.apiUrl}/api/hd/cases/${caseDetail.caseId}`, caseDetail)
-      .pipe(shareReplay());
+    return this.httpClient.put<CaseDto>(`${this.apiUrl}/hd/cases/${caseDetail.caseId}`, caseDetail).pipe(shareReplay());
   }
 
   addComment(caseId: string, comment: string): Observable<any> {
-    return this.httpClient.post(`${this.apiUrl}/api/hd/cases/${caseId}/comments`, { comment }).pipe(shareReplay());
+    return this.httpClient.post(`${this.apiUrl}/hd/cases/${caseId}/comments`, { comment }).pipe(shareReplay());
   }
 
   getCase(caseId: string): Observable<CaseDto> {
-    return this.httpClient.get<CaseDto>(`${this.apiUrl}/api/hd/cases/${caseId}`).pipe(shareReplay());
+    return this.httpClient.get<CaseDto>(`${this.apiUrl}/hd/cases/${caseId}`).pipe(shareReplay());
   }
 
   getCaseActions(caseId: string): Observable<CaseActionDto> {
-    return this.httpClient.get<CaseActionDto>(`${this.apiUrl}/api/hd/actions/${caseId}`).pipe(shareReplay());
+    return this.httpClient.get<CaseActionDto>(`${this.apiUrl}/hd/actions/${caseId}`).pipe(shareReplay());
   }
 
   public get healthDepartment$(): Observable<HealthDepartmentDto> {

--- a/frontend/libs/health-department/domain/src/lib/data-access/index-case.service.ts
+++ b/frontend/libs/health-department/domain/src/lib/data-access/index-case.service.ts
@@ -14,14 +14,14 @@ export class IndexCaseService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
 
   searchCases(searchTerm: string): Observable<CaseSearchItem[]> {
-    return this.httpClient.get<any>(`${this.apiUrl}/api/hd/cases?type=index&q=${searchTerm}&projection=select`).pipe(
+    return this.httpClient.get<any>(`${this.apiUrl}/hd/cases?type=index&q=${searchTerm}&projection=select`).pipe(
       shareReplay(),
       map((res) => res?._embedded?.cases)
     );
   }
 
   getActionList(): Observable<ActionListItemDto[]> {
-    return this.httpClient.get<any>(`${this.apiUrl}/api/hd/actions`).pipe(
+    return this.httpClient.get<any>(`${this.apiUrl}/hd/actions`).pipe(
       shareReplay(),
       map((result) => {
         if (result?._embedded?.actions) {

--- a/frontend/libs/shared/ui-static-pages/src/lib/store/static-page.effects.ts
+++ b/frontend/libs/shared/ui-static-pages/src/lib/store/static-page.effects.ts
@@ -8,7 +8,7 @@ import { API_URL } from '@qro/shared/util-data-access';
 @Injectable()
 export class StaticPageEffects {
   constructor(private actions$: Actions, private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string) {}
-  private baseUrl = `${this.apiUrl}/api`;
+  private baseUrl = `${this.apiUrl}`;
 
   loadStaticPages$ = createEffect(() =>
     this.actions$.pipe(

--- a/frontend/libs/shared/util-symptom/src/lib/data-access/symptom.service.ts
+++ b/frontend/libs/shared/util-symptom/src/lib/data-access/symptom.service.ts
@@ -12,7 +12,7 @@ export class SymptomService {
   constructor(private httpClient: HttpClient, @Inject(API_URL) private apiUrl: string, private store: Store) {}
 
   getSymptoms(languageKey: string): Observable<SymptomDto[]> {
-    let uri = `${this.apiUrl}/api/symptoms`;
+    let uri = `${this.apiUrl}/symptoms`;
     if (!languageKey) {
       return this.store.pipe(
         select(LanguageSelectors.selectedLanguage),


### PR DESCRIPTION
@VILLAN3LL3 – Just a quick review of 3267518. I search and replaced all occurrences of `/api` in the backend access code and end-to-end tests. Happy to merge myself once you give it a green light.