### PR TITLE
Feature/core 585 versenden der registrierung aus app

### DIFF
--- a/backend/src/main/asciidoc/api-agent.adoc
+++ b/backend/src/main/asciidoc/api-agent.adoc
@@ -32,3 +32,20 @@ include::{snippets}/anomalies/access-anomaly/links.adoc[]
 
 [[agent.anomalies.resolve]]
 == Resolving an anomaly
+
+[[agent.registration.send]]
+== Send registration mail
+
+With the response of a registration (GET on `/hd/cases/{case-id}/registration`) you get a link `send-mail`.
+You can follow this link with a `POST`-Request to send the registration e-mail to the recipient.
+The e-mail can be sent if a case exists for the given ID, it has an e-mail address and a valid activation code that has not yet been sent.
+If the e-mail with the currently valid activation link has already been sent, the link `send-mail` is not included in the response.
+Furthermore, the marker `mailed` is present, which indicates whether the e-mail has already been sent.
+
+include::{snippets}/registration/send-mail/curl-request.adoc[]
+
+include::{snippets}/registration/send-mail/auto-path-parameters.adoc[]
+
+The response is the registration in the current state.
+
+include::{snippets}/registration/send-mail/response-body.adoc[]

--- a/backend/src/main/java/quarano/core/web/MappedPayloads.java
+++ b/backend/src/main/java/quarano/core/web/MappedPayloads.java
@@ -541,6 +541,26 @@ public interface MappedPayloads {
 			return this;
 		}
 
+		/**
+		 * Rejects the field with the given name with the given error code if the given condition predicate returns true.
+		 *
+		 * @param condition the condition predicate under which to reject the given field.
+		 * @param field must not be {@literal null} or empty.
+		 * @param errorCode must not be {@literal null} or empty.
+		 * @return the current instance, never {@literal null}.
+		 * @since 1.4
+		 */
+		public MappedPayload<T> rejectField(Predicate<T> condition, String field, String errorCode) {
+
+			Assert.notNull(condition, "Condition predicate must not be null!");
+			Assert.hasText(field, "Field name must not be null or empty!");
+			Assert.hasText(errorCode, "Error code must not be null or empty!");
+
+			return errors.hasErrors() || payload == null || !condition.test(payload)
+					? this
+					: rejectField(field, errorCode);
+		}
+
 		/*
 		 * (non-Javadoc)
 		 * @see quarano.core.web.MappedPayloads.MappedErrors#rejectField(java.lang.String, java.lang.String)

--- a/backend/src/main/java/quarano/department/TrackedCase.java
+++ b/backend/src/main/java/quarano/department/TrackedCase.java
@@ -347,6 +347,13 @@ public class TrackedCase extends QuaranoAggregate<TrackedCase, TrackedCaseIdenti
 		return questionnaire != null;
 	}
 
+	/**
+	 * @since 1.4
+	 */
+	public boolean isEmailAvailable() {
+		return trackedPerson.getEmailAddress() != null;
+	}
+
 	TrackedCase markAsManuallyTracked() {
 
 		assertStatus(Status.OPEN, "Cannot mark case %s as tracked manually as it is in status %s!", id, status);

--- a/backend/src/main/java/quarano/department/TrackedCaseEmail.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEmail.java
@@ -7,7 +7,7 @@ import quarano.tracking.TrackedPersonReceipient;
 
 import java.util.Map;
 
-class TrackedCaseEmail extends AbstractTemplatedEmail {
+public class TrackedCaseEmail extends AbstractTemplatedEmail {
 
 	public TrackedCaseEmail(TrackedCase trackedCase, String subject, EmailTemplates.Key template,
 			Map<String, ? extends Object> placeholders) {

--- a/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
@@ -109,6 +109,7 @@ class TrackedCaseEventListener {
 					.orElseGet(Map::of);
 
 			return emailSender.sendMail(new TrackedCaseEmail(trackedCase, subject, Keys.NEW_CONTACT_CASE, placeholders))
+					.onSuccess(__ -> activationCodes.codeMailed(code.getId()))
 					.onSuccess(__ -> log.info("Contact case creation mail sent to {{}; {}; Case-ID {}}", logArgs))
 					.onFailure(__ -> code.map(ActivationCode::getId).map(activationCodes::cancelCode))
 					.onFailure(e -> log.info("Can't send contact case creation mail to {{}; {}; Case-ID {}}", logArgs))

--- a/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
@@ -9,6 +9,7 @@ import quarano.core.EmailTemplates.Keys;
 import quarano.department.TrackedCase.CaseConvertedToIndex;
 import quarano.department.TrackedCase.CaseCreated;
 import quarano.department.activation.ActivationCode;
+import quarano.department.activation.ActivationCodeProperties;
 import quarano.department.activation.ActivationCodeService;
 
 import java.util.Map;
@@ -109,7 +110,7 @@ class TrackedCaseEventListener {
 					.orElseGet(Map::of);
 
 			return emailSender.sendMail(new TrackedCaseEmail(trackedCase, subject, Keys.NEW_CONTACT_CASE, placeholders))
-					.onSuccess(__ -> activationCodes.codeMailed(code.getId()))
+					.onSuccess(__ -> code.map(ActivationCode::getId).map(activationCodes::codeMailed))
 					.onSuccess(__ -> log.info("Contact case creation mail sent to {{}; {}; Case-ID {}}", logArgs))
 					.onFailure(__ -> code.map(ActivationCode::getId).map(activationCodes::cancelCode))
 					.onFailure(e -> log.info("Can't send contact case creation mail to {{}; {}; Case-ID {}}", logArgs))

--- a/backend/src/main/java/quarano/department/activation/ActivationCode.java
+++ b/backend/src/main/java/quarano/department/activation/ActivationCode.java
@@ -2,6 +2,7 @@ package quarano.department.activation;
 
 import io.vavr.control.Try;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,6 +37,7 @@ import org.jmolecules.ddd.types.Identifier;
 @Table(name = "activation_codes")
 @EqualsAndHashCode(callSuper = true, of = {})
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ActivationCode extends QuaranoAggregate<ActivationCode, ActivationCodeIdentifier> {
 
 	private @Getter LocalDateTime expirationTime;
@@ -43,6 +45,7 @@ public class ActivationCode extends QuaranoAggregate<ActivationCode, ActivationC
 	private @Getter @Enumerated(EnumType.STRING) ActivationCodeStatus status;
 	private @Getter int activationTries;
 	private @Getter DepartmentIdentifier departmentId;
+	private @Getter boolean mailed;
 
 	public ActivationCode(LocalDateTime expirationTime, TrackedPersonIdentifier trackedPersonId,
 			DepartmentIdentifier departmentId) {
@@ -80,6 +83,17 @@ public class ActivationCode extends QuaranoAggregate<ActivationCode, ActivationC
 
 	public boolean isCancelled() {
 		return status == ActivationCodeStatus.CANCELED;
+	}
+
+	/**
+	 * marks the code as mailed
+	 * 
+	 * @since 1.4
+	 */
+	ActivationCode mailed() {
+
+		mailed = true;
+		return this;
 	}
 
 	/**

--- a/backend/src/main/java/quarano/department/activation/ActivationCodeService.java
+++ b/backend/src/main/java/quarano/department/activation/ActivationCodeService.java
@@ -1,5 +1,7 @@
 package quarano.department.activation;
 
+import static java.util.function.Predicate.*;
+
 import io.vavr.control.Try;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +44,7 @@ public class ActivationCodeService {
 
 		return Try.success(personIdentifier)
 				.map(activationCodes::findByTrackedPersonId)
-				.filter(it -> !it.hasRedeemedCode(), ActivationCodeException::activationConcluded)
+				.filter(not(ActivationCodes::hasRedeemedCode), ActivationCodeException::activationConcluded)
 				.map(it -> it.cancelAll(activationCodes::save))
 				.map(__ -> new ActivationCode(configuration.getExpiryDate(), personIdentifier, departmentIdentifier))
 				.map(activationCodes::save);
@@ -71,6 +73,18 @@ public class ActivationCodeService {
 
 		return findCode(identifier)
 				.flatMap(ActivationCode::cancel)
+				.map(activationCodes::save);
+	}
+
+	/**
+	 * marks the code with the given identifier as mailed
+	 * 
+	 * @since 1.4
+	 */
+	public Try<ActivationCode> codeMailed(ActivationCodeIdentifier identifier) {
+
+		return findCode(identifier)
+				.map(ActivationCode::mailed)
 				.map(activationCodes::save);
 	}
 

--- a/backend/src/main/java/quarano/department/web/RegistrationController.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationController.java
@@ -1,9 +1,16 @@
 package quarano.department.web;
 
+import static java.util.function.Predicate.*;
+
+import io.vavr.control.Option;
+import io.vavr.control.Try;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import quarano.account.Account;
 import quarano.account.web.AccountRepresentations;
+import quarano.core.EmailSender;
+import quarano.core.web.I18nedMessage;
 import quarano.core.web.LoggedIn;
 import quarano.core.web.MappedPayloads;
 import quarano.core.web.MappedPayloads.MappedErrors;
@@ -13,17 +20,21 @@ import quarano.department.RegistrationManagement;
 import quarano.department.TrackedCase;
 import quarano.department.TrackedCase.TrackedCaseIdentifier;
 import quarano.department.TrackedCaseRepository;
+import quarano.department.activation.ActivationCode;
 import quarano.department.activation.ActivationCode.ActivationCodeIdentifier;
 import quarano.department.activation.ActivationCodeException;
 import quarano.department.activation.ActivationCodeService;
 import quarano.department.web.RegistrationRepresentations.RegistrationDto;
 
 import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.validation.Valid;
 
+import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
@@ -38,6 +49,7 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class RegistrationController {
 
 	private final @NonNull RegistrationManagement registration;
@@ -45,6 +57,8 @@ public class RegistrationController {
 	private final @NonNull TrackedCaseRepository cases;
 	private final @NonNull AccountRepresentations accountRepresentations;
 	private final @NonNull RegistrationRepresentations representations;
+	private final @NonNull EmailSender emailSender;
+	private final @NonNull MessageSourceAccessor messages;
 
 	private final AcceptHeaderLocaleResolver requestLocaleResolver = new AcceptHeaderLocaleResolver();
 
@@ -72,7 +86,7 @@ public class RegistrationController {
 		}
 
 		return registration.initiateRegistration(trackedCase)
-				.map(it -> representations.toRepresentation(it, trackedCase))
+				.map(it -> representations.toRepresentation(it, trackedCase, account))
 				.fold(it -> ResponseEntity.badRequest().body(it.getMessage()),
 						it -> ResponseEntity.ok(it));
 	}
@@ -82,8 +96,38 @@ public class RegistrationController {
 
 		return cases.findById(id)
 				.filter(it -> it.belongsTo(account.getDepartmentId()))
-				.map(this::toPendingActivationCode)
+				.map(it -> toPendingActivationCode(it, account))
 				.orElseGet(() -> ResponseEntity.notFound().build());
+	}
+
+	/**
+	 * @param id The ID of the tracked case for which the registration mail is to be sent.
+	 * @param account
+	 * @since 1.4
+	 */
+	@PostMapping("/hd/cases/{id}/registration/mail")
+	HttpEntity<?> sendMail(@PathVariable TrackedCaseIdentifier id, @LoggedIn Account account) {
+
+		var trackedCase = cases.findById(id)
+				.filter(it -> it.belongsTo(account.getDepartmentId()))
+				.orElse(null);
+
+		return Option.of(trackedCase)
+				.toEither(ResponseEntity.notFound()::build)
+				.filterOrElse(TrackedCase::isEmailAvailable,
+						__ -> ResponseEntity.unprocessableEntity().body(I18nedMessage.of("NotEmpty.email")))
+				.flatMap(it -> Option.ofOptional(getPendingActivationCode(it))
+						.toEither(ResponseEntity.notFound()::build))
+				.filterOrElse(not(ActivationCode::isMailed),
+						__ -> ResponseEntity.unprocessableEntity().body(I18nedMessage.of("activationCode.alreadyMailed")))
+				.flatMap(code -> {
+
+					return sendActivationMailFor(trackedCase, code, account)
+							.map(__ -> representations.toRepresentation(code, trackedCase, account))
+							.toEither(ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+									.body(I18nedMessage.of("mailService.unavailable")));
+				})
+				.fold(it -> it, ResponseEntity::ok);
 	}
 
 	/**
@@ -119,13 +163,18 @@ public class RegistrationController {
 				.getOrElseGet(it -> ResponseEntity.badRequest().body(it.getMessage()));
 	}
 
-	private HttpEntity<?> toPendingActivationCode(TrackedCase trackedCase) {
+	private HttpEntity<?> toPendingActivationCode(TrackedCase trackedCase, Account officeStaff) {
+
+		return getPendingActivationCode(trackedCase)
+				.<HttpEntity<?>> map(it -> ResponseEntity.ok(representations.toRepresentation(it, trackedCase, officeStaff)))
+				.orElseGet(() -> ResponseEntity.ok(representations.toNoRegistration(trackedCase)));
+	}
+
+	private Optional<ActivationCode> getPendingActivationCode(TrackedCase trackedCase) {
 
 		var personId = trackedCase.getTrackedPerson().getId();
 
-		return registration.getPendingActivationCode(personId)
-				.<HttpEntity<?>> map(it -> ResponseEntity.ok(representations.toRepresentation(it, trackedCase)))
-				.orElseGet(() -> ResponseEntity.ok(representations.toNoRegistration(trackedCase)));
+		return registration.getPendingActivationCode(personId);
 	}
 
 	private static HttpEntity<?> recover(RegistrationException it, MappedErrors errors) {
@@ -138,5 +187,20 @@ public class RegistrationController {
 
 	private static HttpEntity<?> recover(ActivationCodeException it, MappedErrors errors) {
 		return errors.rejectField("clientCode", it.getMessageKey()).toBadRequest();
+	}
+
+	private Try<Void> sendActivationMailFor(TrackedCase trackedCase, ActivationCode code, Account officeStaff) {
+
+		var trackedPerson = trackedCase.getTrackedPerson();
+		var logArgs = new Object[] { trackedPerson.getFullName(), String.valueOf(trackedPerson.getEmailAddress()),
+				trackedCase.getId().toString() };
+
+		var email = representations.getTemplatedEmailFor(trackedCase, code, officeStaff);
+
+		return emailSender.sendMail(email)
+				.onSuccess(__ -> activationCodes.codeMailed(code.getId()))
+				.onSuccess(__ -> log.info("Contact registration mail sent to {{}; {}; Case-ID {}}", logArgs))
+				.onFailure(e -> log.info("Can't send registration mail to {{}; {}; Case-ID {}}", logArgs))
+				.onFailure(e -> log.info("Exception", e));
 	}
 }

--- a/backend/src/main/java/quarano/department/web/RegistrationRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/RegistrationRepresentations.java
@@ -6,8 +6,11 @@ import io.jsonwebtoken.lang.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import quarano.account.Account;
 import quarano.core.CoreProperties;
+import quarano.core.EmailSender.TemplatedEmail;
 import quarano.core.EmailTemplates;
 import quarano.core.EmailTemplates.Keys;
 import quarano.core.validation.UserName;
@@ -15,6 +18,7 @@ import quarano.core.web.MapperWrapper;
 import quarano.department.RegistrationDetails;
 import quarano.department.TrackedCase;
 import quarano.department.TrackedCase.TrackedCaseIdentifier;
+import quarano.department.TrackedCaseEmail;
 import quarano.department.activation.ActivationCode;
 
 import java.time.LocalDate;
@@ -27,6 +31,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
 
+import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.hateoas.IanaLinkRelations;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Links;
@@ -46,10 +51,11 @@ class RegistrationRepresentations {
 	private final EmailTemplates templates;
 	private final CoreProperties configuration;
 	private final MapperWrapper mapper;
+	private final @NonNull MessageSourceAccessor messages;
 
-	PendingRegistration toRepresentation(ActivationCode code, TrackedCase trackedCase) {
+	PendingRegistration toRepresentation(ActivationCode code, TrackedCase trackedCase, Account officeStaff) {
 
-		var email = getEmailTemplateFor(trackedCase, code);
+		var email = getEmailTemplateFor(trackedCase, code, officeStaff);
 		var result = PendingRegistration.of(trackedCase.getId(), code, email);
 
 		return result.add(TrackedCaseStatusAware.getDefaultLinks(trackedCase));
@@ -59,11 +65,39 @@ class RegistrationRepresentations {
 		return mapper.map(payload, RegistrationDetails.class);
 	}
 
-	private String getEmailTemplateFor(TrackedCase trackedCase, ActivationCode code) {
+	String getEmailTemplateFor(TrackedCase trackedCase, ActivationCode code, Account officeStaff) {
+
+		var key = determineRegistrationMailKey(trackedCase);
+		var placeholders = createRegistrationMailPlaceholders(trackedCase, code, officeStaff);
+
+		return templates.expandTemplate(key, placeholders, trackedCase.getTrackedPerson().getLocale());
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	TemplatedEmail getTemplatedEmailFor(TrackedCase trackedCase, ActivationCode code, Account officeStaff) {
+
+		var trackedPerson = trackedCase.getTrackedPerson();
+		var subject = messages.getMessage("RegistriationMail.subject",
+				new Object[] { trackedCase.getDepartment().getName() }, trackedPerson.getLocale());
+
+		var key = determineRegistrationMailKey(trackedCase);
+		var placeholders = createRegistrationMailPlaceholders(trackedCase, code, officeStaff);
+
+		return new TrackedCaseEmail(trackedCase, subject, key, placeholders);
+	}
+
+	private HashMap<String, Object> createRegistrationMailPlaceholders(TrackedCase trackedCase, ActivationCode code,
+			Account officeStaff) {
 
 		var placeholders = new HashMap<String, Object>();
 
 		placeholders.put("lastName", trackedCase.getTrackedPerson().getLastName());
+		placeholders.put("departmentName", trackedCase.getDepartment().getName());
+		placeholders.put("staffFullName", officeStaff.getFullName());
+		placeholders.put("staffLastName", officeStaff.getLastname());
+		placeholders.put("staffFirstName", officeStaff.getFirstname());
 		placeholders.put("host", configuration.getHost());
 		placeholders.put("activationCode", code.getId().toString());
 
@@ -73,9 +107,11 @@ class RegistrationRepresentations {
 			placeholders.put("quarantineEndDate", quarantine.getTo().format(FORMATTER));
 		}
 
-		var key = trackedCase.isIndexCase() ? Keys.REGISTRATION_INDEX : Keys.REGISTRATION_CONTACT;
+		return placeholders;
+	}
 
-		return templates.expandTemplate(key, placeholders, trackedCase.getTrackedPerson().getLocale());
+	private Keys determineRegistrationMailKey(TrackedCase trackedCase) {
+		return trackedCase.isIndexCase() ? Keys.REGISTRATION_INDEX : Keys.REGISTRATION_CONTACT;
 	}
 
 	RepresentationModel<?> toNoRegistration(TrackedCase trackedCase) {
@@ -104,6 +140,13 @@ class RegistrationRepresentations {
 			return code.getExpirationTime();
 		}
 
+		/**
+		 * @since 1.4
+		 */
+		public Boolean isMailed() {
+			return code.isMailed();
+		}
+
 		public String getEmail() {
 			return email;
 		}
@@ -122,7 +165,9 @@ class RegistrationRepresentations {
 					Link.of(fromMethodCall(controller.getRegistrationDetails(trackedCaseIdentifier, null)).toUriString(),
 							IanaLinkRelations.SELF),
 					Link.of(fromMethodCall(controller.createRegistration(trackedCaseIdentifier, null)).toUriString(),
-							TrackedCaseLinkRelations.RENEW)));
+							TrackedCaseLinkRelations.RENEW)))
+					.andIf(!isMailed(), Link.of(fromMethodCall(controller.sendMail(trackedCaseIdentifier, null)).toUriString(),
+							TrackedCaseLinkRelations.SEND_MAIL));
 		}
 	}
 

--- a/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
@@ -13,6 +13,7 @@ public class TrackedCaseLinkRelations {
 	public static final LinkRelation START_TRACKING = LinkRelation.of("start-tracking");
 	public static final LinkRelation CONCLUDE = LinkRelation.of("conclude");
 	public static final LinkRelation RENEW = LinkRelation.of("renew");
+	public static final LinkRelation SEND_MAIL = LinkRelation.of("send-mail");
 
 	public static final LinkRelation QUESTIONNAIRE = LinkRelation.of("questionnaire");
 	public static final LinkRelation CASES = LinkRelation.of("cases");

--- a/backend/src/main/resources/db/migration/V1016__Add_was_sent_to_activation_code.sql
+++ b/backend/src/main/resources/db/migration/V1016__Add_was_sent_to_activation_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activation_codes ADD mailed bool NULL;

--- a/backend/src/main/resources/messages.properties
+++ b/backend/src/main/resources/messages.properties
@@ -58,6 +58,7 @@ Invalid.accountRegistration.username=Der eingegebene Benutzername ist nicht zul�
 Invalid.activationCode.NOT_FOUND=Der von Ihnen eingegebene Anmeldecode ist falsch. Bitte überprüfen Sie, ob er genau dem Code entspricht, den Sie per E-Mail erhalten haben. Wenn nicht, melden Sie sich bitte umgehend telefonisch bei Ihrem Gesundheitsamt.
 Invalid.activationCode.EXPIRED=Der von Ihnen eingegebene Anmeldecode ist abgelaufen! Bitte kontaktieren sie das Gesundheitsamt um einen neuen Code zu bekommen. Dieser ist 24 Stunden gültig.
 Invalid.activationCode.USED_OR_CANCELED=Der von Ihnen eingegebene Anmeldecode ist entweder nicht aktuell oder bereits benutzt worden. Bitte überprüfen Sie, ob Sie einen neueren Code vom Gesundheitsamt erhalten haben.
+activationCode.alreadyMailed=Der Anmeldecode wurde bereits an den Nutzer geschickt.
 
 #Roles
 quarano.account.RoleType.role-hd-admin=Admin
@@ -119,8 +120,11 @@ quarano.diary.Slot.TimeOfDay.1.morning=Morgen des {0}
 quarano.diary.Slot.TimeOfDay.2.evening=Abend des {0}
 
 # Mails
-NewContactCaseMail.subject=Information vom {0}
+NewContactCaseMail.subject={0}: Information für gemeldeten Kontakt
 DiaryEntryReminderMail.subject=Erinnerung an Covid-19 Symptomtagebuch
+RegistriationMail.subject={0}: Registrierungs-Link für Covid-19 Tagebuch
+
+mailService.unavailable=Mailversand im Moment nicht möglich. Bitte wenden Sie sich an einen Administrator!
 
 # ZIP code check
 wrong.trackedPersonDto.zipCode=Die PLZ {0} kann keinem Gesundheitsamt zugeordnet werden. Bitte überprüfen Sie Ihre Eingabe, denn Sie können nur mit einer gültigen PLZ Quarano verwenden!

--- a/backend/src/main/resources/messages_en.properties
+++ b/backend/src/main/resources/messages_en.properties
@@ -58,6 +58,7 @@ Invalid.accountRegistration.username=The user name entered is not permissible!
 Invalid.activationCode.NOT_FOUND=The sign-in code you've used doesn't work. Please check if it is exactly the code you've received via email. If that isn't the case, please contact your health authority immediately via phone.
 Invalid.activationCode.EXPIRED=The sign-in code you've used is expired. Please contact your health authority to receive a new code. All codes are valid for 24 hours.
 Invalid.activationCode.USED_OR_CANCELED=The sign-in code you've used isn't the most recent one or has been used before. Please check if you've received a newer code from your health authority.
+activationCode.alreadyMailed=The sign-in code has already been mailed to the user.
 
 # Roles
 quarano.account.RoleType.role-hd-admin=Admin
@@ -117,8 +118,11 @@ quarano.diary.Slot.TimeOfDay.1.morning=Morning of {0}
 quarano.diary.Slot.TimeOfDay.2.evening=Evening of {0}
 
 # Mails
-NewContactCaseMail.subject=Information from {0}
+NewContactCaseMail.subject={0}: Information for reported contact
 DiaryEntryReminderMail.subject=Reminder about Covid-19 Symptom Diary
+RegistriationMail.subject={0}: Registration link for Covid-19 Diary
+
+mailService.unavailable=Mail sending not possible at the moment. Please contact an administrator!
 
 # ZIP code check
 wrong.trackedPersonDto.zipCode=The zip code {0} cannot be assigned to any public health department. Please check your input, because you can only use Quarano with a valid zip code!

--- a/backend/src/test/java/quarano/department/CreateActivationCodeForNewContactCaseTests.java
+++ b/backend/src/test/java/quarano/department/CreateActivationCodeForNewContactCaseTests.java
@@ -1,0 +1,113 @@
+package quarano.department;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.vavr.control.Try;
+import quarano.QuaranoUnitTest;
+import quarano.account.Department;
+import quarano.account.DepartmentContact;
+import quarano.account.DepartmentContact.ContactType;
+import quarano.core.EmailAddress;
+import quarano.core.EmailSender;
+import quarano.core.EmailSender.AbstractTemplatedEmail;
+import quarano.department.TrackedCase.CaseCreated;
+import quarano.department.TrackedCaseEventListener.EmailSendingEvents;
+import quarano.department.activation.ActivationCode;
+import quarano.department.activation.ActivationCodeProperties;
+import quarano.department.activation.ActivationCodeService;
+import quarano.tracking.TrackedPerson;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.support.MessageSourceAccessor;
+
+@QuaranoUnitTest
+@TestInstance(Lifecycle.PER_METHOD)
+public class CreateActivationCodeForNewContactCaseTests {
+
+	private @Mock EmailSender emailSender;
+	private @Mock RegistrationManagement registration;
+	private @Mock TrackedCaseRepository cases;
+	private @Mock MessageSourceAccessor messages;
+	private @Mock ActivationCodeService activationCodes;
+	private @Mock ActivationCodeProperties activationProperties;
+
+	private @InjectMocks EmailSendingEvents events;
+
+	@Captor
+	ArgumentCaptor<AbstractTemplatedEmail> templateCaptor;
+
+	@BeforeEach
+	public void initTests() {
+
+		when(emailSender.testConnection()).thenReturn(Try.success(null));
+
+		events.on(mock(ApplicationReadyEvent.class));
+	}
+
+	@Test // CORE-618
+	void withoutAutomaticCreationOfActivationCode() {
+
+		var trackedCase = trackedCase();
+
+		when(activationProperties.isCreateAutomaticForNewContacts()).thenReturn(false);
+
+		events.on(CaseCreated.of(trackedCase));
+
+		verify(registration, never()).initiateRegistration(trackedCase);
+		verify(emailSender).sendMail(templateCaptor.capture());
+
+		assertThat(templateCaptor.getValue().getPlaceholders()).doesNotContainKey("activationCode");
+	}
+
+	@Test // CORE-618
+	void withAutomaticCreationOfActivationCode() {
+
+		var trackedCase = trackedCase();
+
+		var code = new ActivationCode(LocalDateTime.now(), trackedCase.getTrackedPerson().getId(),
+				trackedCase.getDepartment().getId());
+
+		when(activationProperties.isCreateAutomaticForNewContacts()).thenReturn(true);
+		when(registration.initiateRegistration(trackedCase)).thenReturn(Try.success(code));
+		when(emailSender.sendMail(any())).thenReturn(Try.success(null));
+
+		events.on(CaseCreated.of(trackedCase));
+
+		verify(registration).initiateRegistration(trackedCase);
+		verify(activationCodes).codeMailed(code.getId());
+
+		verify(emailSender).sendMail(templateCaptor.capture());
+
+		assertThat(templateCaptor.getValue().getPlaceholders()).extractingByKey("activationCode")
+				.isEqualTo(code.getId().toString());
+	}
+
+	private TrackedCase trackedCase() {
+
+		var person = new TrackedPerson("Max", "Muster");
+		var department = mock(Department.class);
+		var depContact = mock(DepartmentContact.class);
+
+		person.setEmailAddress(EmailAddress.of("max@muster-test.de"));
+
+		when(depContact.getEmailAddress()).thenReturn(EmailAddress.of("email@test-ga.de"));
+
+		when(department.getName()).thenReturn("Test GA");
+		when(department.getContact(ContactType.CONTACT)).thenReturn(Optional.of(depContact));
+
+		return new TrackedCase(person, CaseType.CONTACT, department);
+	}
+}

--- a/backend/src/test/java/quarano/department/MailForNewContactCaseEventListenerTests.java
+++ b/backend/src/test/java/quarano/department/MailForNewContactCaseEventListenerTests.java
@@ -52,7 +52,7 @@ class MailForNewContactCaseEventListenerTests {
 
 		mailServer.assertEmailSent(message -> {
 
-			assertThat(message.getSubject()).isEqualTo("Information vom GA Mannheim");
+			assertThat(message.getSubject()).isEqualTo("GA Mannheim: Information für gemeldeten Kontakt");
 			assertThat(GreenMailUtil.getBody(message)).startsWith("Sehr geehrte/geehrter Frau/Herr Mueller,");
 			assertThat(message.getRecipients(RecipientType.TO)[0].toString())
 					.isEqualTo("Tanja Mueller <tanja.mueller@testtest.de>");


### PR DESCRIPTION
The response of a registration (e.g. of GET /hd/cases/{id}/registration) contains a link send-mail now. With this link the e-mail can be sent and only if this link is available.

With a POST-request on /hd/cases/{id}/registration/mail the e-mail can be sent if a case exists for the given ID, it has an e-mail address and a valid activation code that has not yet been sent.

The response is the current state of the registration.

A new state in ActivationCode persists if it has already been sent.

A second commit insert a toggle for activation code creation with the automatic mail to new contact persons. It can now be set whether an activation code is generated with this automatic emails.