### PR TITLE
CORE-468 Removes configurably the recording of contacts from contacts at enrollment.

### DIFF
--- a/backend/src/main/java/quarano/department/TrackedCase.java
+++ b/backend/src/main/java/quarano/department/TrackedCase.java
@@ -250,11 +250,15 @@ public class TrackedCase extends QuaranoAggregate<TrackedCase, TrackedCaseIdenti
 		return this;
 	}
 
-	public TrackedCase report(TestResult testResult) {
+	public TrackedCase report(TestResult testResult, boolean executeContactRetroForContactCases) {
+		 
+ 		if (this.type != CaseType.INDEX && testResult.isInfected()) {
+ 			registerEvent(CaseConvertedToIndex.of(this));
 
-		if (this.type != CaseType.INDEX && testResult.isInfected()) {
-			registerEvent(CaseConvertedToIndex.of(this));
-		}
+			if (!executeContactRetroForContactCases) {
+				reopenEnrollment();
+			}
+ 		}
 
 		this.testResult = testResult;
 		this.type = testResult.isInfected() ? CaseType.INDEX : type;

--- a/backend/src/main/java/quarano/department/TrackedCaseProperties.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseProperties.java
@@ -15,6 +15,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConfigurationProperties("quarano.cases")
 public class TrackedCaseProperties {
 
+	private final boolean executeContactRetroForContactCases;
 	private final Period quarantinePeriod;
 
 	public Period getQuarantinePeriod() {

--- a/backend/src/main/java/quarano/department/web/DepartmentMappingConfiguration.java
+++ b/backend/src/main/java/quarano/department/web/DepartmentMappingConfiguration.java
@@ -1,8 +1,11 @@
 package quarano.department.web;
 
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import quarano.core.web.MappingCustomizer;
 import quarano.department.TestResult;
 import quarano.department.TrackedCase;
+import quarano.department.TrackedCaseProperties;
 import quarano.department.web.TrackedCaseRepresentations.TrackedCaseDto;
 import quarano.tracking.Quarantine;
 
@@ -21,7 +24,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Order(30)
+@RequiredArgsConstructor
 public class DepartmentMappingConfiguration implements MappingCustomizer {
+
+	private final @NonNull TrackedCaseProperties caseProperties;
 
 	/*
 	 * (non-Javadoc)
@@ -55,7 +61,8 @@ public class DepartmentMappingConfiguration implements MappingCustomizer {
 			var testDate = source.getTestDate();
 
 			if (source.getTestDate() != null) {
-				target.report(source.isInfected() ? TestResult.infected(testDate) : TestResult.notInfected(testDate));
+				target.report(source.isInfected() ? TestResult.infected(testDate) : TestResult.notInfected(testDate),
+						caseProperties.isExecuteContactRetroForContactCases());
 			}
 
 			return target;

--- a/backend/src/main/java/quarano/department/web/TrackedCaseController.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseController.java
@@ -346,18 +346,6 @@ public class TrackedCaseController {
 				.build();
 	}
 
-	@DeleteMapping("/enrollment/completion")
-	HttpEntity<?> reopenEnrollment(@LoggedIn TrackedPerson person) {
-
-		cases.findByTrackedPerson(person)
-				.map(TrackedCase::reopenEnrollment)
-				.map(cases::save);
-
-		return ResponseEntity.ok()
-				.header(HttpHeaders.LOCATION, getEnrollmentLink())
-				.build();
-	}
-
 	private Collection<TrackedCaseContactSummary> createContactSummaries(TrackedCase trackedCase) {
 
 		var encounters = trackedCase.getTrackedPerson().getEncounters();

--- a/backend/src/main/java/quarano/department/web/TrackedCaseCsvController.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseCsvController.java
@@ -412,7 +412,7 @@ class TrackedCaseCsvController {
 		TrackedCase trackedCase = new TrackedCase(person, CaseType.INDEX, department);
 		trackedCase.addOriginCase(new TrackedCase(person, CaseType.INDEX, department));
 		trackedCase.setQuarantine(Quarantine.of(LocalDate.now().minusDays(7), LocalDate.now().plusDays(7)));
-		trackedCase.report(TestResult.infected(LocalDate.now().minusDays(4)));
+		trackedCase.report(TestResult.infected(LocalDate.now().minusDays(4)), false);
 
 		try {
 			var lastModField = AuditingMetadata.class.getDeclaredField("lastModified");

--- a/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseLinkRelations.java
@@ -25,7 +25,6 @@ public class TrackedCaseLinkRelations {
 
 	static final LinkRelation DETAILS = LinkRelation.of("details");
 	static final LinkRelation ENCOUNTERS = LinkRelation.of("encounters");
-	static final LinkRelation REOPEN = LinkRelation.of("reopen");
 
 	public static final LinkRelation CONFIRM = LinkRelation.of("confirm");
 }

--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -593,14 +593,13 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 
 			var enrollmentLink = MvcLink.of(caseController.enrollment(null), SELF);
 			var questionnareLink = MvcLink.of(caseController.addQuestionaire(null, null, null), QUESTIONNAIRE);
-			var reopenLink = MvcLink.of(caseController.reopenEnrollment(null), REOPEN);
 			var detailsLink = MvcLink.of(trackingController.enrollmentOverview(null), DETAILS);
 			var encountersLink = MvcLink.of(trackingController.getEncounters(null), ENCOUNTERS);
 
 			var links = Links.NONE.and(enrollmentLink, detailsLink);
 
 			if (enrollment.isComplete()) {
-				links = links.and(questionnareLink, encountersLink, reopenLink);
+				links = links.and(questionnareLink, encountersLink);
 			} else if (enrollment.isCompletedQuestionnaire()) {
 
 				links = links.and(questionnareLink, encountersLink, questionnareLink.withRel(PREV),

--- a/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
+++ b/backend/src/main/java/quarano/department/web/TrackedCaseRepresentations.java
@@ -33,6 +33,7 @@ import quarano.department.Questionnaire;
 import quarano.department.Questionnaire.SymptomInformation;
 import quarano.department.TrackedCase;
 import quarano.department.TrackedCase.TrackedCaseIdentifier;
+import quarano.department.TrackedCaseProperties;
 import quarano.department.TrackedCaseRepository;
 import quarano.diary.DiaryEntry;
 import quarano.masterdata.SymptomRepository;
@@ -65,9 +66,10 @@ import javax.validation.constraints.Pattern;
 import javax.validation.groups.Default;
 
 import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.data.util.Streamable;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.LinkRelation;
 import org.springframework.hateoas.Links;
-import org.springframework.hateoas.Links.MergeMode;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.mediatype.hal.HalModelBuilder;
 import org.springframework.hateoas.server.core.Relation;
@@ -100,6 +102,7 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 	private final @NonNull SymptomRepository symptoms;
 	private final @NonNull ContactChaser contactChaser;
 	private final @NonNull HealthDepartments rkiDepartments;
+	private final @NonNull TrackedCaseProperties caseProperties;
 
 	private final @NonNull List<TrackedCaseDetailsEnricher> enrichers;
 
@@ -136,8 +139,8 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 		return halModelBuilder.build();
 	}
 
-	public EnrollmentDto toRepresentation(Enrollment enrollment) {
-		return new EnrollmentDto(enrollment);
+	public EnrollmentDto toEnrollmentRepresentation(TrackedCase trackedCase) {
+		return new EnrollmentDto(trackedCase, caseProperties.isExecuteContactRetroForContactCases());
 	}
 
 	InstitutionDto toRepresentation(HealthDepartment department) {
@@ -546,7 +549,8 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 
 	@Data
 	static class CommentInput {
-		@Textual String comment;
+		@Textual
+		String comment;
 	}
 
 	static class ValidationGroups {
@@ -556,10 +560,29 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 		interface Contact {}
 	}
 
-	@RequiredArgsConstructor
 	public static class EnrollmentDto extends RepresentationModel<EnrollmentDto> {
 
 		private final @Getter(onMethod = @__(@JsonUnwrapped)) Enrollment enrollment;
+		private final boolean executeContactRetroForContactCases;
+		private final boolean isIndexCase;
+
+		public EnrollmentDto(TrackedCase trackedCase, boolean executeContactRetroForContactCases) {
+
+			this.enrollment = trackedCase.getEnrollment();
+			this.isIndexCase = trackedCase.isIndexCase();
+			this.executeContactRetroForContactCases = executeContactRetroForContactCases;
+		}
+
+		public List<String> getSteps() {
+
+			var relations = Streamable.of(DETAILS, QUESTIONNAIRE);
+
+			if (isIndexCase || executeContactRetroForContactCases) {
+				relations = relations.and(ENCOUNTERS);
+			}
+
+			return relations.map(LinkRelation::value).toList();
+		}
 
 		@Override
 		@SuppressWarnings("null")
@@ -574,11 +597,26 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 			var detailsLink = MvcLink.of(trackingController.enrollmentOverview(null), DETAILS);
 			var encountersLink = MvcLink.of(trackingController.getEncounters(null), ENCOUNTERS);
 
-			return Links.NONE.and(enrollmentLink, detailsLink)
-					.andIf(enrollment.isComplete(), questionnareLink, encountersLink, reopenLink)
-					.andIf(enrollment.isCompletedQuestionnaire(), questionnareLink, encountersLink, encountersLink.withRel(NEXT))
-					.andIf(enrollment.isCompletedPersonalData(), questionnareLink, questionnareLink.withRel(NEXT))
-					.merge(MergeMode.SKIP_BY_REL, detailsLink.withRel(NEXT));
+			var links = Links.NONE.and(enrollmentLink, detailsLink);
+
+			if (enrollment.isComplete()) {
+				links = links.and(questionnareLink, encountersLink, reopenLink);
+			} else if (enrollment.isCompletedQuestionnaire()) {
+
+				links = links.and(questionnareLink, encountersLink, questionnareLink.withRel(PREV),
+						encountersLink.withRel(NEXT));
+
+			} else if (enrollment.isCompletedPersonalData()) {
+				links = links.and(questionnareLink, detailsLink.withRel(PREV), questionnareLink.withRel(NEXT));
+			} else {
+				links = links.and(detailsLink.withRel(NEXT));
+			}
+
+			if (!isIndexCase) {
+				links = links.without(ENCOUNTERS);
+			}
+
+			return links;
 		}
 	}
 
@@ -607,13 +645,19 @@ public class TrackedCaseRepresentations implements ExternalTrackedCaseRepresenta
 	@EqualsAndHashCode(callSuper = true)
 	static class InstitutionDto extends RepresentationModel<InstitutionDto> {
 
-		@Pattern(regexp = Strings.NAMES) String name;
+		@Pattern(regexp = Strings.NAMES)
+		String name;
 		String department;
-		@Pattern(regexp = Strings.STREET) String street;
-		@Pattern(regexp = Strings.CITY) String city;
-		@Pattern(regexp = ZipCode.PATTERN) String zipCode;
-		@Pattern(regexp = PhoneNumber.PATTERN) String fax, phone;
-		@Email String email;
+		@Pattern(regexp = Strings.STREET)
+		String street;
+		@Pattern(regexp = Strings.CITY)
+		String city;
+		@Pattern(regexp = ZipCode.PATTERN)
+		String zipCode;
+		@Pattern(regexp = PhoneNumber.PATTERN)
+		String fax, phone;
+		@Email
+		String email;
 
 		private static InstitutionDto of(HealthDepartment rkiDepartment) {
 

--- a/backend/src/main/java/quarano/user/web/UserController.java
+++ b/backend/src/main/java/quarano/user/web/UserController.java
@@ -72,15 +72,14 @@ public class UserController {
 			var trackedCase = person.flatMap(cases::findByTrackedPerson);
 
 			trackedCase
-					.map(TrackedCase::getEnrollment)
+					.map(representations::toEnrollmentRepresentation)
 					.ifPresent(it -> {
 
-						var enrollmentDto = representations.toRepresentation(it);
 						var enrollmentLink = MvcLink.of(caseController.enrollment(null), ENROLLMENT);
 
-						userDto.setEnrollment(enrollmentDto)
+						userDto.setEnrollment(it)
 								.add(enrollmentLink)
-								.addIf(!it.isComplete(),
+								.addIf(!it.getEnrollment().isComplete(),
 										() -> MvcLink.of(caseController.enrollment(null), ENROLLMENT).withRel(IanaLinkRelations.NEXT));
 					});
 

--- a/backend/src/main/java/quarano/user/web/UserRepresentations.java
+++ b/backend/src/main/java/quarano/user/web/UserRepresentations.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2020 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package quarano.user.web;
 
 import lombok.AccessLevel;
@@ -29,7 +14,7 @@ import quarano.account.Password.UnencryptedPassword;
 import quarano.core.EmailAddress;
 import quarano.core.validation.UserName;
 import quarano.core.web.MapperWrapper;
-import quarano.department.Enrollment;
+import quarano.department.TrackedCase;
 import quarano.department.web.TrackedCaseRepresentations;
 import quarano.department.web.TrackedCaseRepresentations.EnrollmentDto;
 import quarano.tracking.TrackedPerson;
@@ -58,8 +43,8 @@ class UserRepresentations {
 	private final MapperWrapper mapper;
 	private final TrackedCaseRepresentations delegate;
 
-	EnrollmentDto toRepresentation(Enrollment enrollment) {
-		return delegate.toRepresentation(enrollment);
+	EnrollmentDto toEnrollmentRepresentation(TrackedCase trackedCase) {
+		return delegate.toEnrollmentRepresentation(trackedCase);
 	}
 
 	DepartmentDto toRepresentation(Department department) {
@@ -128,7 +113,8 @@ class UserRepresentations {
 		/**
 		 * The current password.
 		 */
-		@NotBlank String current;
+		@NotBlank
+		String current;
 
 		PasswordChangeRequest(String current, String password, String passwordConfirm) {
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -56,6 +56,8 @@ quarano.anomalies.temperature-threshold=37.9f
 quarano.diary.tolerated-slot-count=1
 # quarano.diary.reminder.enable=false
 
+quarano.cases.execute-contact-retro-for-contact-cases=false
+
 quarano.department.default-department.name=GA Mannheim
 # RKI code for the department from TransmittingSiteSearchText.xml
 # quarano.department.default-department.rki-code=Set this only in the concrete environment to avoid errors (e.g. 1.08.2.22.).

--- a/backend/src/test/java/quarano/actions/web/AnomaliesControllerWebIntegrationTests.java
+++ b/backend/src/test/java/quarano/actions/web/AnomaliesControllerWebIntegrationTests.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.RepresentationModel;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultHandler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -96,8 +95,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		reviewed.setComment("Comment!");
 
 		var response = mvc.perform(put("/hd/actions/{id}/resolve", trackedCase.getId())
-				.content(jackson.writeValueAsString(reviewed))
-				.contentType(MediaType.APPLICATION_JSON))
+				.content(jackson.writeValueAsString(reviewed)))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -113,7 +111,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 	@WithQuaranoUser("agent3")
 	void resolvesAnomaliesManuallyDoesNotWorkForSystemAnomalies() throws Exception {
 
-		var actionsResponse = mvc.perform(get("/hd/actions").accept("application/json"))
+		var actionsResponse = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andDo(documentAnomalies())
 				.andReturn().getResponse().getContentAsString();
@@ -125,8 +123,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 				.setComment("Comment!");
 
 		var response = mvc.perform(put("/hd/actions/{id}/resolve", contactCaseId)
-				.content(jackson.writeValueAsString(reviewed))
-				.contentType(MediaType.APPLICATION_JSON))
+				.content(jackson.writeValueAsString(reviewed)))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -150,8 +147,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 		var reviewed = new ActionsReviewed().setComment("Comment!");
 
 		mvc.perform(put("/hd/actions/{id}/resolve", trackedCase.getId())
-				.content(jackson.writeValueAsString(reviewed))
-				.contentType(MediaType.APPLICATION_JSON))
+				.content(jackson.writeValueAsString(reviewed)))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -176,7 +172,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 	void getActionsDoesNotReturnConcludedCases() throws Exception {
 
 		// get an active case with open actions
-		var actionsResponse = mvc.perform(get("/hd/actions").accept("application/json"))
+		var actionsResponse = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -210,8 +206,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 				.filter(it -> it.originatesFrom(originCase))
 				.stream().findFirst().orElseThrow();
 
-		var response = mvc.perform(get("/hd/actions")
-				.accept("application/hal+json"))
+		var response = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 
@@ -250,7 +245,7 @@ class AnomaliesControllerWebIntegrationTests extends AbstractDocumentation {
 				.orElseThrow();
 
 		// get an active case with open actions
-		var actionsResponse = mvc.perform(get("/hd/actions").accept("application/json"))
+		var actionsResponse = mvc.perform(get("/hd/actions"))
 				.andExpect(status().isOk())
 				.andReturn().getResponse().getContentAsString();
 

--- a/backend/src/test/java/quarano/department/TrackedCaseUnitTests.java
+++ b/backend/src/test/java/quarano/department/TrackedCaseUnitTests.java
@@ -154,8 +154,8 @@ class TrackedCaseUnitTests {
 
 		var trackedCase = new TrackedCase(person, CaseType.CONTACT, department);
 
-		assertThat(trackedCase.report(TestResult.notInfected(LocalDate.now())).isIndexCase()).isFalse();
-		assertThat(trackedCase.report(TestResult.infected(LocalDate.now())).isIndexCase()).isTrue();
+		assertThat(trackedCase.report(TestResult.notInfected(LocalDate.now()), false).isIndexCase()).isFalse();
+		assertThat(trackedCase.report(TestResult.infected(LocalDate.now()), false).isIndexCase()).isTrue();
 	}
 
 	@ParameterizedTest

--- a/frontend/libs/client/domain/src/lib/model/enrollment-status.ts
+++ b/frontend/libs/client/domain/src/lib/model/enrollment-status.ts
@@ -5,6 +5,7 @@ export interface EnrollmentStatusDto extends HalResponse {
   completedQuestionnaire: boolean;
   completedContactRetro: boolean;
   complete: boolean;
+  steps: string[];
 }
 
 export function getEmptyEnrollmentStatus(): EnrollmentStatusDto {
@@ -13,5 +14,6 @@ export function getEmptyEnrollmentStatus(): EnrollmentStatusDto {
     completedQuestionnaire: false,
     completedContactRetro: false,
     complete: false,
+    steps: [],
   };
 }

--- a/frontend/libs/client/feature-enrollment/src/lib/basic-data/basic-data.component.html
+++ b/frontend/libs/client/feature-enrollment/src/lib/basic-data/basic-data.component.html
@@ -42,13 +42,25 @@
           (buttonClicked)="checkAndSendQuestionaire()"
           [loading]="secondFormLoading"
           data-cy="second-step-button"
+          *ngIf="showThirdStep; else COMPLETE_ENROLLMENT_BUTTON"
         >
           <mat-icon>arrow_forward</mat-icon> {{ 'BASIC_DATA.WEITER' | translate }}
         </qro-button>
+        <ng-template #COMPLETE_ENROLLMENT_BUTTON>
+          <qro-button
+            class="ml-3"
+            (buttonClicked)="checkAndSendQuestionaire()"
+            [disabled]="secondStep.hasError"
+            [loading]="secondFormLoading"
+            data-cy="second-step-complete-button"
+          >
+            <mat-icon>check</mat-icon> {{ 'BASIC_DATA.ERFASSUNG_ABSCHLIESSEN' | translate }}
+          </qro-button>
+        </ng-template>
       </div>
     </form>
   </mat-step>
-  <mat-step #thirdStep [stepControl]="thirdFormGroup">
+  <mat-step #thirdStep [stepControl]="thirdFormGroup" *ngIf="showThirdStep">
     <ng-template matStepLabel>{{ 'BASIC_DATA.KONTAKTPERSONEN' | translate }}</ng-template>
     <div class="info-text">
       <h2>{{ 'BASIC_DATA.UMGANG_MIT_KONTAKTPERSONEN' | translate }}</h2>

--- a/frontend/libs/client/feature-enrollment/src/lib/basic-data/basic-data.component.ts
+++ b/frontend/libs/client/feature-enrollment/src/lib/basic-data/basic-data.component.ts
@@ -62,6 +62,7 @@ export class BasicDataComponent implements OnInit, OnDestroy, AfterViewChecked, 
   encounters: EncounterEntry[] = [];
   noRetrospectiveContactsConfirmed = false;
   thirdFormLoading = false;
+  showThirdStep = true;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -72,7 +73,6 @@ export class BasicDataComponent implements OnInit, OnDestroy, AfterViewChecked, 
     private router: Router,
     private changeDetect: ChangeDetectorRef,
     private badRequestService: BadRequestService,
-    private clientService: ProfileService,
     private dialogService: ContactDialogService,
     public clientStore: ClientStore,
     private store: Store,
@@ -101,6 +101,7 @@ export class BasicDataComponent implements OnInit, OnDestroy, AfterViewChecked, 
   ngAfterViewInit(): void {
     this.subs.add(
       this.clientStore.enrollmentStatus$.pipe(take(1)).subscribe((status) => {
+        this.showThirdStep = status.steps.includes('encounters');
         if (status.completedPersonalData) {
           this.stepper?.next();
         }
@@ -324,7 +325,12 @@ export class BasicDataComponent implements OnInit, OnDestroy, AfterViewChecked, 
           )
           .subscribe(
             (result) => {
-              this.stepper.next();
+              if (this.showThirdStep) {
+                this.stepper.next();
+              } else {
+                this.subs.add(this.snackbarService.success('BASIC_DATA.REGISTRIERUNG_ABGESCHLOSSEN').subscribe());
+                this.router.navigate(['/client/diary/diary-list']);
+              }
             },
             (error) => {
               this.badRequestService.handleBadRequestError(error, this.secondFormGroup);

--- a/frontend/libs/shared/util-snackbar/src/lib/translated-snackbar.service.ts
+++ b/frontend/libs/shared/util-snackbar/src/lib/translated-snackbar.service.ts
@@ -2,7 +2,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Injectable } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar, MatSnackBarConfig } from '@angular/material/snack-bar';
 import { Observable } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { first, map, tap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -22,28 +22,38 @@ export class TranslatedSnackbarService {
     const config = new MatSnackBarConfig();
     config.panelClass = ['background-green'];
     config.duration = this.duration;
-    return this.translate
-      .get(messageKey, params)
-      .pipe(map((result: string) => this.snackbar.open(result, null, config)));
+    return this.translate.get(messageKey, params).pipe(
+      first(),
+      map((result: string) => this.snackbar.open(result, null, config))
+    );
   }
 
   error(messageKey: string): Observable<MatSnackBarRef<SimpleSnackBar>> {
     const config = new MatSnackBarConfig();
     config.panelClass = ['background-red'];
-    return this.translate.get(messageKey).pipe(map((result: string) => this.snackbar.open(result, 'x', config)));
+    return this.translate.get(messageKey).pipe(
+      first(),
+      map((result: string) => this.snackbar.open(result, 'x', config))
+    );
   }
 
   warning(messageKey: string): Observable<MatSnackBarRef<SimpleSnackBar>> {
     const config = new MatSnackBarConfig();
     config.panelClass = ['background-orange'];
     config.duration = this.duration;
-    return this.translate.get(messageKey).pipe(map((result: string) => this.snackbar.open(result, null, config)));
+    return this.translate.get(messageKey).pipe(
+      first(),
+      map((result: string) => this.snackbar.open(result, null, config))
+    );
   }
 
   message(messageKey: string) {
     const config = new MatSnackBarConfig();
     config.duration = this.duration;
     config.panelClass = ['light-primary-color'];
-    return this.translate.get(messageKey).pipe(map((result: string) => this.snackbar.open(result, null, config)));
+    return this.translate.get(messageKey).pipe(
+      first(),
+      map((result: string) => this.snackbar.open(result, null, config))
+    );
   }
 }


### PR DESCRIPTION
There is a new property to control whether to perform the contact
recording during the enrollment for a contact case. If no contact
recording is to be made, this is skipped for contact cases.

The links to the next and previous steps are returned accordingly. An
array of the necessary steps for the breadcrumbs is also supplied with
the EnrollmentDto.

The enrollment is reopened when a contact case is converted to an index
case.

+ Deletes the unnecessary endpoint DELETE on /enrollment/completion and the link to it.