### PR TITLE
CORE-294 implements anonymization and partial deletion of personal data

### DIFF
--- a/backend/src/main/asciidoc/deployment.adoc
+++ b/backend/src/main/asciidoc/deployment.adoc
@@ -70,3 +70,17 @@ Deployments need to specify the following properties:
 * `server.ssl.trust-store-password` -- the password to access the trust store.
 * `server.ssl.trust-store-type` -- set to `JKS`
 * `server.ssl.client-auth` -- set to `want` to enable client certificate authentication
+
+[[deployment.properties]]
+== Properties
+
+[options="header",cols="1,3,1"]
+|===
+|Property   |Description |Value
+//-------------
+|`quarano.date-time.delta` |A delta as a period to the current date, which is used especially when saving data in the database for creation and modification dates. |example = `-6m-1d`   
+|`quarano.gdpr.cases.anonymization-after`   |Defines the period after that a case will be anonymized starting from the creation date. |default = `6m`
+|`quarano.gdpr.contacts.anonymization-after`|Defines the period after that a contact will be anonymized starting from the creation date. |default = `16d`
+|`quarano.gdpr.occations.delete-occasions-after`   |Defines the period after that a occation will be deleted starting from the creation date. |default = `6m`
+|`quarano.gdpr.occations.delete-visitors-after`|Defines the period after that a visitor group with its visitors will be deleted starting from the creation date of its occation. |default = `16d`
+|===

--- a/backend/src/main/asciidoc/index.adoc
+++ b/backend/src/main/asciidoc/index.adoc
@@ -5,6 +5,8 @@ include::intro.adoc[]
 
 include::api.adoc[]
 
+include::runtime.adoc[]
+
 include::deployment.adoc[]
 
 include::developer.adoc[]

--- a/backend/src/main/asciidoc/runtime.adoc
+++ b/backend/src/main/asciidoc/runtime.adoc
@@ -1,0 +1,69 @@
+[[runtime]]
+= Runtime information
+
+[[runtime.gdpr-jobs]]
+== GDPR Delete/Anonymization Jobs
+
+The idea with GDPR implementation is to only overwrite the personal data (### for text makes anonymization clear or Null for other data types) and not delete the whole records. By anonymizing, we avoid some problems with dependencies between data that have to be taken into account in different places if anything is to be deleted. Besides, the possibility for statistical analysis e.g. on the level of the postal code or the city remains.
+
+The following three domains in the data are handled separately as follows:
+
+1. Once a day during the night, a job runs that deletes all occasions that were created more than 6 months ago. Furthermore, for all occasions created more than 16 days ago, the associated visitors are deleted. This data is so loosely connected to the rest of the data model that deletion is easy to implement.
+
+1. Once a day during the night, a job runs that anonymizes (for what exactly see later overview) all contacts (not contact persons or contact cases) that were created more than 16 days ago. Only from non-anonymized contacts cases are created, in case of later conversion.
+
+1. Once a day during the night, a job runs that anonymizes all cases created more than 6 months ago. Thereby all relevant referenced data (e.g. account, person, ...) are anonymized (what exactly see later overview). Anonymized cases are no longer included in the overviews and exports. Therefore the cases get a corresponding status.
+
+When to delete is adjustable (<<deployment.properties,Properties>>).
+
+To enable tests of these time-related functions, it is now possible to specify a delta for the creation and modification time of the data via the property `quarano.date-time.delta` (<<deployment.properties,Properties>>). This only works in non-production environments.
+
+The following data will be anonymized (these are tables and columns in the DB). The data from the tables occasions, visitor_groups and visitors will be deleted (*DB version v1020*):
+
+* accounts
+    ** username
+    ** firstname
+    ** lastname
+    ** email
+    ** password
+
+* tracked_people
+    ** first_name
+    ** last_name
+    ** date_of_birth
+    ** phone_number
+    ** mobile_phone_number
+    ** email
+    ** street
+    ** house_number
+
+* tracked_cases
+    ** ext_reference_number
+
+* comments
+    ** author
+    ** text
+
+* questionnaires
+    ** family_doctor
+    ** guessed_origin_of_infection
+    ** has_pre_existing_conditions_description
+    ** belong_to_medical_staff_description
+    ** has_contact_to_vulnerable_people_description
+
+* diary_entries
+    ** note
+
+* action_items
+    ** arguments
+
+* contact_people
+    ** first_name
+    ** last_name
+    ** phone_number
+    ** mobile_phone_number
+    ** email
+    ** street
+    ** house_number
+    ** identification_hint
+    ** remark

--- a/backend/src/main/java/quarano/account/Account.java
+++ b/backend/src/main/java/quarano/account/Account.java
@@ -1,5 +1,7 @@
 package quarano.account;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -168,6 +170,37 @@ public class Account extends QuaranoAggregate<Account, AccountIdentifier> {
 	 */
 	public boolean wasPasswordResetRequested() {
 		return passwordResetToken != null;
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	public Account anonymize() {
+
+		setUsername("###");
+		setFirstname("###");
+		setLastname("###");
+		setEmail(null);
+		setPassword(EncryptedPassword.of("###"));
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	Account fillSampleData() {
+
+		firstname = defaultIfNull(firstname, "firstname");
+		lastname = defaultIfNull(lastname, "lastname");
+		email = defaultIfNull(email, EmailAddress.of("email@address.xx"));
+		username = defaultIfNull(username, "username");
+		password = defaultIfNull(password, EncryptedPassword.of("password"));
+
+		return this;
 	}
 
 	/**

--- a/backend/src/main/java/quarano/actions/ActionItem.java
+++ b/backend/src/main/java/quarano/actions/ActionItem.java
@@ -1,5 +1,7 @@
 package quarano.actions;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,6 +21,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.jmolecules.ddd.types.Identifier;
 
 /**
@@ -59,6 +62,35 @@ public abstract class ActionItem extends QuaranoAggregate<ActionItem, ActionItem
 
 	public boolean isManuallyResolvable() {
 		return getDescription().getCode().isManuallyResolvable();
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	public ActionItem anonymize() {
+
+		description = Description.of(description.getCode(), "###");
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	public ActionItem fillSampleData() {
+
+		var fallback = Description.of(description.getCode(), "arguments");
+
+		description = defaultIfNull(description, fallback);
+
+		if (description.getArguments() == null || ArrayUtils.contains(description.getArguments(), "")) {
+			description = fallback;
+		}
+
+		return this;
 	}
 
 	public float getWeight() {

--- a/backend/src/main/java/quarano/actions/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/actions/TrackedCaseEventListener.java
@@ -3,6 +3,8 @@ package quarano.actions;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import quarano.department.GDPRAnonymizationJob.CasesAnonymized;
+import quarano.department.TrackedCase;
 import quarano.department.TrackedCase.CaseConcluded;
 import quarano.department.TrackedCase.CaseCreated;
 import quarano.department.TrackedCase.CaseStatusUpdated;
@@ -58,6 +60,20 @@ class TrackedCaseEventListener {
 
 					openItems.resolveManually(items::save);
 				});
+	}
+
+	@EventListener
+	void on(CasesAnonymized event) {
+
+		var cases = event.getCases();
+
+		log.debug("actions of {} cases are anonymized!", cases.size());
+
+		for (TrackedCase trackedCase : cases) {
+			items.saveAll(items.findByCase(trackedCase).map(ActionItem::anonymize).toList());
+		}
+
+		log.info("actions of {} cases were anonymized!", cases.size());
 	}
 
 	private void handleCreatedOrUpdatedCase(TrackedCaseIdentifier identifier) {

--- a/backend/src/main/java/quarano/core/QuaranoDateTimeProvider.java
+++ b/backend/src/main/java/quarano/core/QuaranoDateTimeProvider.java
@@ -1,30 +1,41 @@
 package quarano.core;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Optional;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Oliver Drotbohm
+ * @author Jens Kutzsche
  */
 @Component
 public class QuaranoDateTimeProvider implements DateTimeProvider {
 
-	private Period delta = Period.ZERO;
+	private DateTimeProperties properties;
+	private @Getter @Setter TemporalAmount delta;
 
-	/**
-	 * @param delta the delta to set
-	 */
-	public void setDelta(Period delta) {
-		this.delta = delta;
+	public QuaranoDateTimeProvider(@Nullable DateTimeProperties properties) {
+
+		this.properties = properties;
+
+		delta = properties != null ? properties.getDelta() : Period.ZERO;
 	}
 
 	public void reset() {
-		this.delta = Period.ZERO;
+		this.delta = properties.getDelta();
 	}
 
 	/*
@@ -34,5 +45,18 @@ public class QuaranoDateTimeProvider implements DateTimeProvider {
 	@Override
 	public Optional<TemporalAccessor> getNow() {
 		return Optional.of(LocalDateTime.now().plus(delta));
+	}
+
+	@ConstructorBinding
+	@ConfigurationProperties("quarano.date-time")
+	@RequiredArgsConstructor
+	@Profile("!prod")
+	public static class DateTimeProperties {
+
+		private final Period delta;
+
+		public Period getDelta() {
+			return delta != null ? delta : Period.ZERO;
+		}
 	}
 }

--- a/backend/src/main/java/quarano/department/Comment.java
+++ b/backend/src/main/java/quarano/department/Comment.java
@@ -1,5 +1,7 @@
 package quarano.department;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -52,6 +54,28 @@ public class Comment extends QuaranoEntity<TrackedCase, CommentIdentifier> imple
 	 */
 	public Comment(String text, String author) {
 		this(text, author, LocalDateTime.now());
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	Comment anonymize() {
+
+		author = "###";
+		text = "###";
+
+		return this;
+	}
+
+	Comment fillSampleData() {
+
+		author = defaultIfNull(author, "author");
+		text = defaultIfNull(text, "text");
+
+		return this;
 	}
 
 	/*

--- a/backend/src/main/java/quarano/department/GDPRAnonymizationJob.java
+++ b/backend/src/main/java/quarano/department/GDPRAnonymizationJob.java
@@ -1,0 +1,87 @@
+package quarano.department;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import quarano.diary.DiaryManagement;
+import quarano.tracking.ContactPersonRepository;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Collection;
+
+import org.jmolecules.event.types.DomainEvent;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * This class collects all old data from cases with their person and related data and anonymizes the personal data to be
+ * GDPR compliant.
+ *
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@Component("department.GDPRAnonymizationJob")
+@Slf4j
+@RequiredArgsConstructor
+public class GDPRAnonymizationJob {
+
+	private final @NonNull TrackedCaseRepository cases;
+	private final @NonNull ContactPersonRepository contacts;
+	private final @NonNull DiaryManagement diaries;
+	private final @NonNull CaseAnonymizationProperties properties;
+	private final @NonNull ApplicationEventPublisher eventPublisher;
+
+	@Transactional
+	@Scheduled(cron = "0 10 1 * * *")
+	void anonymizeCasesAndRelatedData() {
+
+		var refDate = LocalDate.now().minus(properties.getAnonymizationAfter()).atStartOfDay();
+
+		var oldCases = cases.findByMetadataCreatedIsBefore(refDate).toList();
+
+		log.debug(
+				"{} cases with their person, account, comments, questionnaire and diaries are anonymized {} days after their creation!",
+				oldCases.size(),
+				properties.getAnonymizationAfter().getDays());
+
+		oldCases.forEach(TrackedCase::anonymize);
+		cases.saveAll(oldCases);
+
+		oldCases.stream().forEach(it -> diaries.anonymizeDiaryFor(it.getTrackedPerson()));
+
+		eventPublisher.publishEvent(CasesAnonymized.of(oldCases));
+
+		log.info(
+				"{} cases with their person, account, comments, questionnaire and diaries were anonymized {} days after their creation!",
+				oldCases.size(),
+				properties.getAnonymizationAfter().getDays());
+	}
+
+	@ConstructorBinding
+	@RequiredArgsConstructor
+	@ConfigurationProperties("quarano.gdpr.cases")
+	public static class CaseAnonymizationProperties {
+
+		private final Period DEFAULT_ANONYMIZATION_AFTER = Period.ofMonths(6);
+
+		/**
+		 * Defines the {@link Period} after that a case will be anonymized starting from the creation date.
+		 */
+		private final Period anonymizationAfter;
+
+		public Period getAnonymizationAfter() {
+			return anonymizationAfter == null ? DEFAULT_ANONYMIZATION_AFTER : anonymizationAfter;
+		}
+	}
+
+	@Value(staticConstructor = "of")
+	public static class CasesAnonymized implements DomainEvent {
+		Collection<TrackedCase> cases;
+	}
+}

--- a/backend/src/main/java/quarano/department/Questionnaire.java
+++ b/backend/src/main/java/quarano/department/Questionnaire.java
@@ -21,6 +21,7 @@ import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.jmolecules.ddd.types.Identifier;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -153,6 +154,40 @@ public class Questionnaire extends QuaranoEntity<TrackedCase, QuestionnaireIdent
 
 	public boolean belongsToMedicalStaff() {
 		return belongToMedicalStaff;
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	Questionnaire anonymize() {
+
+		setFamilyDoctor("###");
+		setGuessedOriginOfInfection("###");
+		setHasPreExistingConditionsDescription("###");
+		setBelongToMedicalStaffDescription("###");
+		setHasContactToVulnerablePeopleDescription("###");
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	Questionnaire fillSampleData() {
+
+		familyDoctor = ObjectUtils.defaultIfNull(familyDoctor, "familyDoctor");
+		guessedOriginOfInfection = ObjectUtils.defaultIfNull(guessedOriginOfInfection, "guessedOriginOfInfection");
+		hasPreExistingConditionsDescription = ObjectUtils.defaultIfNull(hasPreExistingConditionsDescription,
+				"hasPreExistingConditionsDescription");
+		belongToMedicalStaffDescription = ObjectUtils.defaultIfNull(belongToMedicalStaffDescription,
+				"belongToMedicalStaffDescription");
+		hasContactToVulnerablePeopleDescription = ObjectUtils.defaultIfNull(hasContactToVulnerablePeopleDescription,
+				"hasContactToVulnerablePeopleDescription");
+
+		return this;
 	}
 
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/backend/src/main/java/quarano/department/RegistrationDataInitializer.java
+++ b/backend/src/main/java/quarano/department/RegistrationDataInitializer.java
@@ -33,7 +33,7 @@ class RegistrationDataInitializer implements DataInitializer {
 	 */
 	@Override
 	public void preInitialize() {
-		dateTimeProvider.setDelta(Period.ofDays(-3));
+		dateTimeProvider.setDelta(Period.from(dateTimeProvider.getDelta()).minusDays(3));
 	}
 
 	/*

--- a/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseEventListener.java
@@ -45,6 +45,7 @@ class TrackedCaseEventListener {
 				.stream()
 				.flatMap(CaseSource::forAllContacts)
 				.filter(it -> !cases.existsByOriginContacts(it.getPerson()))
+				.filter(it -> !it.getPerson().isAnonymized())
 				.peek(it -> log.info("Created automatic contact case from contact " + it.getPerson().getId()))
 				.map(TrackedCase::of)
 				.forEach(cases::save);

--- a/backend/src/main/java/quarano/department/TrackedCaseQuerydslFilters.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseQuerydslFilters.java
@@ -55,7 +55,7 @@ public interface TrackedCaseQuerydslFilters {
 
 			var $case = QTrackedCase.trackedCase;
 			var $casePerson = $case.trackedPerson;
-			var builder = new BooleanBuilder();
+			var builder = new BooleanBuilder().and($case.status.ne(Status.ANONYMIZED));
 
 			var predicate = query.map(it -> builder.and($casePerson.firstName.containsIgnoreCase(it)
 					.or($casePerson.lastName.containsIgnoreCase(it))))
@@ -94,7 +94,8 @@ public interface TrackedCaseQuerydslFilters {
 			var $address = $casePerson.address;
 			var $zipCode = $address.zipCode;
 
-			var builder = new BooleanBuilder($case.quarantineLastModified.isNotNull());
+			var builder = new BooleanBuilder($case.quarantineLastModified.isNotNull())
+					.and($case.status.ne(Status.ANONYMIZED));
 
 			if (Optionals.isAnyPresent(quarantineChangedFrom, quarantineChangedTo)) {
 
@@ -136,10 +137,9 @@ public interface TrackedCaseQuerydslFilters {
 			var $caseMetadata = $case.metadata;
 			var person = $case.trackedPerson;
 			var $personMetadata = person.metadata;
-			var $address = person.address;
-			var $zipCode = $address.zipCode;
 
-			var builder = new BooleanBuilder($caseMetadata.lastModified.isNotNull());
+			var builder = new BooleanBuilder($caseMetadata.lastModified.isNotNull())
+					.and($case.status.ne(Status.ANONYMIZED));
 
 			if (Optionals.isAnyPresent(createdFrom, createdTo)) {
 

--- a/backend/src/main/java/quarano/department/TrackedCaseRepository.java
+++ b/backend/src/main/java/quarano/department/TrackedCaseRepository.java
@@ -8,6 +8,7 @@ import quarano.tracking.ContactPerson;
 import quarano.tracking.TrackedPerson;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
@@ -25,10 +26,10 @@ public interface TrackedCaseRepository
 					+ "join fetch c.trackedPerson p "
 					+ "join fetch c.department d ";
 
-	@Query(DEFAULT_SELECT + " where d.id = :identifier")
+	@Query(DEFAULT_SELECT + " where c.status != 'ANONYMIZED' and d.id = :identifier")
 	Streamable<TrackedCase> findByDepartmentId(DepartmentIdentifier identifier);
 
-	@Query(DEFAULT_SELECT + " where d.id = :id order by p.lastName")
+	@Query(DEFAULT_SELECT + " where c.status != 'ANONYMIZED' and d.id = :id order by p.lastName")
 	Streamable<TrackedCase> findByDepartmentIdOrderByLastNameAsc(DepartmentIdentifier id);
 
 	Optional<TrackedCase> findByTrackedPerson(TrackedPerson person);
@@ -54,4 +55,14 @@ public interface TrackedCaseRepository
 	 * @return
 	 */
 	Optional<TrackedCase> findByOriginContacts(ContactPerson person);
+
+	/**
+	 * Returns the {@link TrackedCase}s which are not yet anonymized and created before the given {@link LocalDateTime}.
+	 * 
+	 * @param refDate must not be {@literal null}.
+	 * @return
+	 * @since 1.4
+	 */
+	@Query(DEFAULT_SELECT + " where c.status != 'ANONYMIZED' and c.metadata.created < :refDate")
+	Streamable<TrackedCase> findByMetadataCreatedIsBefore(LocalDateTime refDate);
 }

--- a/backend/src/main/java/quarano/department/TrackingEventListener.java
+++ b/backend/src/main/java/quarano/department/TrackingEventListener.java
@@ -53,7 +53,7 @@ public class TrackingEventListener {
 
 		try {
 
-			if (event.isFirstEncounterWithTargetPerson()) {
+			if (event.isFirstEncounterWithTargetPerson() && !contactPerson.isAnonymized()) {
 				createContactCase(event.getPersonIdentifier(), contactPerson);
 			}
 

--- a/backend/src/main/java/quarano/diary/DiaryEntry.java
+++ b/backend/src/main/java/quarano/diary/DiaryEntry.java
@@ -1,5 +1,7 @@
 package quarano.diary;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -131,6 +133,29 @@ public class DiaryEntry extends QuaranoAggregate<DiaryEntry, DiaryEntryIdentifie
 
 	public boolean isBefore(DiaryEntry entry) {
 		return this.slot.isBefore(entry.slot);
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	DiaryEntry anonymize() {
+
+		setNote("###");
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	public DiaryEntry fillSampleData() {
+
+		note = defaultIfNull(note, "note");
+
+		return this;
 	}
 
 	/*

--- a/backend/src/main/java/quarano/diary/DiaryEntryRepository.java
+++ b/backend/src/main/java/quarano/diary/DiaryEntryRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.util.Streamable;
 /**
  * @author Oliver Drotbohm
  */
-interface DiaryEntryRepository extends CrudRepository<DiaryEntry, DiaryEntryIdentifier> {
+public interface DiaryEntryRepository extends CrudRepository<DiaryEntry, DiaryEntryIdentifier> {
 
 	/**
 	 * We can only prefetch one of the related collections during a query. We resolve the symptoms with the first query as

--- a/backend/src/main/java/quarano/diary/DiaryManagement.java
+++ b/backend/src/main/java/quarano/diary/DiaryManagement.java
@@ -50,4 +50,14 @@ public class DiaryManagement {
 	public Streamable<TrackedPersonIdentifier> findMissingDiaryEntryPersons(List<Slot> slots) {
 		return diaries.findMissingDiaryEntryPersons(slots);
 	}
+
+	/**
+	 * anonymized personal data of all diary entries of the given {@link TrackedPerson}
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	public void anonymizeDiaryFor(TrackedPerson trackedPerson) {
+		diaries.saveAll(findDiaryFor(trackedPerson).map(it -> it.anonymize()).toList());
+	}
 }

--- a/backend/src/main/java/quarano/occasion/GDPRDeleteJob.java
+++ b/backend/src/main/java/quarano/occasion/GDPRDeleteJob.java
@@ -1,0 +1,117 @@
+package quarano.occasion;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import quarano.account.DepartmentRepository;
+import quarano.tracking.TrackedPersonRepository;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * This class collects all old occasion and visitor data and anonymizes the personal data to be GDPR compliant.
+ *
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+class GDPRDeleteJob {
+
+	private final @NonNull TrackedPersonRepository people;
+	private final @NonNull DepartmentRepository departments;
+	private final @NonNull OccasionRepository occasions;
+	private final @NonNull OccationDeletionProperties properties;
+
+	@Transactional
+	@Scheduled(cron = "0 10 0 * * *")
+	void deleteOccasions() {
+
+		var refDate = LocalDate.now().minus(properties.getDeleteOccasionsAfter()).atStartOfDay();
+
+		var oldOccasions = occasions.findByMetadataCreatedIsBefore(refDate).toList();
+
+		log.debug("{} occasions are deleted {} days after their creation!",
+				oldOccasions.size(),
+				properties.getDeleteOccasionsAfter().getDays());
+
+		occasions.deleteAll(oldOccasions);
+
+		log.info("{} occasions were deleted {} days after their creation!",
+				oldOccasions.size(),
+				properties.getDeleteOccasionsAfter().getDays());
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 20 0 * * *")
+	void deleteVisitors() {
+
+		var refDate = LocalDate.now().minus(properties.getDeleteVisitorsAfter()).atStartOfDay();
+
+		var oldOccasions = occasions.findByMetadataCreatedIsBefore(refDate).toList();
+
+		log.debug("Visitor groups and visitors of {} occasions are deleted {} days after their creation!",
+				(long) oldOccasions.size(),
+				properties.getDeleteOccasionsAfter().getDays());
+
+		deleteVisitorsOf(oldOccasions);
+
+		log.info("Visitor groups and visitors of {} occasions were deleted {} days after their creation!",
+				(long) oldOccasions.size(),
+				properties.getDeleteOccasionsAfter().getDays());
+	}
+
+	private void deleteVisitorsOf(List<Occasion> oldOccasions) {
+
+		occasions.deleteAllVisitors(oldOccasions.stream()
+				.flatMap(it -> it.getVisitorGroups().stream())
+				.flatMap(it -> (it.getVisitors() != null ? it.getVisitors() : List.<Visitor> of()).stream())
+				.collect(Collectors.toList()));
+
+		occasions.deleteVisitorGroupsByOccasionCodeIn(oldOccasions.stream()
+				.map(Occasion::getOccasionCode)
+				.collect(Collectors.toList()));
+
+		occasions.saveAll(oldOccasions.stream()
+				.peek(it -> it.getVisitorGroups().clear())
+				.collect(Collectors.toList()));
+	}
+
+	@ConstructorBinding
+	@RequiredArgsConstructor
+	@ConfigurationProperties("quarano.gdpr.occasions")
+	public static class OccationDeletionProperties {
+
+		private final Period DEFAULT_DELETE_OCCASIONS_AFTER = Period.ofMonths(6);
+		private final Period DEFAULT_DELETE_VISITORS_AFTER = Period.ofDays(16);
+
+		/**
+		 * Defines the {@link Period} after that a occation will be deleted starting from the creation date.
+		 */
+		private final Period deleteOccasionsAfter;
+
+		/**
+		 * Defines the {@link Period} after that a visitor group with its visitors will be deleted starting from the
+		 * creation date of its occation.
+		 */
+		private final Period deleteVisitorsAfter;
+
+		public Period getDeleteOccasionsAfter() {
+			return deleteOccasionsAfter == null ? DEFAULT_DELETE_OCCASIONS_AFTER : deleteOccasionsAfter;
+		}
+
+		public Period getDeleteVisitorsAfter() {
+			return deleteVisitorsAfter == null ? DEFAULT_DELETE_VISITORS_AFTER : deleteVisitorsAfter;
+		}
+	}
+}

--- a/backend/src/main/java/quarano/occasion/OccasionRepository.java
+++ b/backend/src/main/java/quarano/occasion/OccasionRepository.java
@@ -3,9 +3,12 @@ package quarano.occasion;
 import quarano.core.QuaranoRepository;
 import quarano.occasion.Occasion.OccasionIdentifier;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.util.Streamable;
 
 /**
  * @author David Bauknecht
@@ -32,4 +35,27 @@ interface OccasionRepository extends QuaranoRepository<Occasion, OccasionIdentif
 	 */
 	@Query("select o from Occasion o where o.occasionCode = :occasionCode")
 	Optional<Occasion> findByOccasionCode(OccasionCode occasionCode);
+
+	/**
+	 * Returns the {@link Occasion}s created before the given {@link LocalDateTime}.
+	 * 
+	 * @param refDate must not be {@literal null}.
+	 * @return
+	 */
+	Streamable<Occasion> findByMetadataCreatedIsBefore(LocalDateTime refDate);
+
+	/**
+	 * Deletes all visitor groups with the given occasion codes.
+	 *
+	 * @param entities must not be {@literal null}. Must not contain {@literal null} elements.
+	 * @throws IllegalArgumentException in case the given {@literal occasionCode} or one of its entities is
+	 *           {@literal null}.
+	 */
+	@Modifying
+	@Query("delete from VisitorGroup vg where vg.occasionCode in :occasionCodes")
+	void deleteVisitorGroupsByOccasionCodeIn(Iterable<OccasionCode> occasionCodes);
+
+	@Modifying
+	@Query("delete from Visitor v where v in :visitors")
+	void deleteAllVisitors(Iterable<Visitor> visitors);
 }

--- a/backend/src/main/java/quarano/occasion/Visitor.java
+++ b/backend/src/main/java/quarano/occasion/Visitor.java
@@ -5,10 +5,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import quarano.core.Address;
 import quarano.core.EmailAddress;
 import quarano.core.PhoneNumber;
 import quarano.core.QuaranoAggregate;
-import quarano.core.Address;
 
 import java.io.Serializable;
 import java.time.LocalDate;

--- a/backend/src/main/java/quarano/tracking/ContactPerson.java
+++ b/backend/src/main/java/quarano/tracking/ContactPerson.java
@@ -1,5 +1,7 @@
 package quarano.tracking;
 
+import static org.apache.commons.lang3.ObjectUtils.*;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,9 +11,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Value;
 import quarano.core.Address;
+import quarano.core.Address.HouseNumber;
 import quarano.core.EmailAddress;
 import quarano.core.PhoneNumber;
 import quarano.core.QuaranoAggregate;
+import quarano.core.ZipCode;
 import quarano.tracking.ContactPerson.ContactPersonIdentifier;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
@@ -56,6 +60,7 @@ public class ContactPerson extends QuaranoAggregate<ContactPerson, ContactPerson
 	private @Getter @Setter Boolean isHealthStaff;
 	private @Getter @Setter Boolean isSenior;
 	private @Getter @Setter Boolean hasPreExistingConditions;
+	private @Getter @Setter boolean anonymized;
 
 	@Column(nullable = false)
 	@AttributeOverride(name = "trackedPersonId", column = @Column(name = "tracked_person_id"))
@@ -97,6 +102,54 @@ public class ContactPerson extends QuaranoAggregate<ContactPerson, ContactPerson
 		this.phoneNumber = contactWays.getPhoneNumber();
 		this.mobilePhoneNumber = contactWays.getMobilePhoneNumber();
 		this.identificationHint = contactWays.getIdentificationHint();
+
+		return this;
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	ContactPerson anonymize() {
+
+		firstName = "###";
+		lastName = "###";
+		phoneNumber = null;
+		mobilePhoneNumber = null;
+		emailAddress = null;
+		identificationHint = "###";
+		remark = "###";
+
+		if (address != null) {
+			address.setStreet(null);
+			address.setHouseNumber(null);
+		}
+
+		anonymized = true;
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	ContactPerson fillSampleData() {
+
+		firstName = defaultIfNull(firstName, "firstName");
+		lastName = defaultIfNull(lastName, "lastName");
+		phoneNumber = defaultIfNull(phoneNumber, PhoneNumber.of("12345"));
+		mobilePhoneNumber = defaultIfNull(mobilePhoneNumber, PhoneNumber.of("67890"));
+		emailAddress = defaultIfNull(emailAddress, EmailAddress.of("email@address.xx"));
+		identificationHint = defaultIfNull(identificationHint, "identificationHint");
+		remark = defaultIfNull(remark, "remark");
+
+		address = defaultIfNull(address, new Address());
+		address.setCity(defaultIfNull(address.getCity(), "city"));
+		address.setZipCode(defaultIfNull(address.getZipCode(), ZipCode.of("11111")));
+		address.setStreet(defaultIfNull(address.getStreet(), "street"));
+		address.setHouseNumber(defaultIfNull(address.getHouseNumber(), HouseNumber.of("111")));
 
 		return this;
 	}

--- a/backend/src/main/java/quarano/tracking/ContactPersonRepository.java
+++ b/backend/src/main/java/quarano/tracking/ContactPersonRepository.java
@@ -4,14 +4,28 @@ import quarano.core.QuaranoRepository;
 import quarano.tracking.ContactPerson.ContactPersonIdentifier;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.util.Streamable;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Oliver Drotbohm
+ * @author Jens Kutzsche
  */
 @Repository("newContactRepository")
 public interface ContactPersonRepository extends QuaranoRepository<ContactPerson, ContactPersonIdentifier> {
 
 	Streamable<ContactPerson> findByOwnerId(TrackedPersonIdentifier ownerId);
+
+	/**
+	 * Returns the {@link ContactPerson}s which are not yet anonymized and created before the given {@link LocalDateTime}.
+	 * 
+	 * @param refDate must not be {@literal null}.
+	 * @return
+	 * @since 1.4
+	 */
+	@Query("select c from ContactPerson c where c.anonymized = FALSE and c.metadata.created < :refDate")
+	Streamable<ContactPerson> findByMetadataCreatedIsBefore(LocalDateTime refDate);
 }

--- a/backend/src/main/java/quarano/tracking/GDPRAnonymizationJob.java
+++ b/backend/src/main/java/quarano/tracking/GDPRAnonymizationJob.java
@@ -1,0 +1,63 @@
+package quarano.tracking;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * This class collects all old data from contacts and anonymizes the personal data to be GDPR compliant.
+ *
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@Component("tracking.GDPRAnonymizationJob")
+@Slf4j
+@RequiredArgsConstructor
+class GDPRAnonymizationJob {
+
+	private final @NonNull ContactPersonRepository contacts;
+	private final @NonNull ContactAnonymizationProperties properties;
+
+	@Transactional
+	@Scheduled(cron = "0 40 1 * * *")
+	void anonymizeContactsAndRelatedData() {
+
+		var refDate = LocalDate.now().minus(properties.getAnonymizationAfter()).atStartOfDay();
+
+		var oldContacts = contacts.findByMetadataCreatedIsBefore(refDate).toList();
+
+		log.debug(oldContacts.size() + " contacts are anonymized!");
+
+		oldContacts.forEach(ContactPerson::anonymize);
+		contacts.saveAll(oldContacts);
+
+		log.info("{} contacts were anonymized {} days after their creation!", oldContacts.size(),
+				properties.getAnonymizationAfter().getDays());
+	}
+
+	@ConstructorBinding
+	@RequiredArgsConstructor
+	@ConfigurationProperties("quarano.gdpr.contacts")
+	public static class ContactAnonymizationProperties {
+
+		private final Period DEFAULT_ANONYMIZATION_AFTER = Period.ofDays(16);
+
+		/**
+		 * Defines the {@link Period} after that a contact will be anonymized starting from the creation date.
+		 */
+		private final Period anonymizationAfter;
+
+		public Period getAnonymizationAfter() {
+			return anonymizationAfter == null ? DEFAULT_ANONYMIZATION_AFTER : anonymizationAfter;
+		}
+	}
+}

--- a/backend/src/main/java/quarano/tracking/TrackedPerson.java
+++ b/backend/src/main/java/quarano/tracking/TrackedPerson.java
@@ -1,6 +1,7 @@
 package quarano.tracking;
 
 import static java.util.Comparator.*;
+import static org.apache.commons.lang3.ObjectUtils.*;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,9 +13,11 @@ import lombok.Setter;
 import lombok.Value;
 import quarano.account.Account;
 import quarano.core.Address;
+import quarano.core.Address.HouseNumber;
 import quarano.core.EmailAddress;
 import quarano.core.PhoneNumber;
 import quarano.core.QuaranoAggregate;
+import quarano.core.ZipCode;
 import quarano.tracking.Encounter.EncounterIdentifier;
 import quarano.tracking.TrackedPerson.TrackedPersonIdentifier;
 
@@ -217,6 +220,53 @@ public class TrackedPerson extends QuaranoAggregate<TrackedPerson, TrackedPerson
 	public TrackedPerson setLocale(@Nullable Locale locale) {
 
 		this.locale = locale == null ? null : LocaleUtils.toLocale(locale.getLanguage());
+
+		return this;
+	}
+
+	/**
+	 * anonymized personal data
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	public TrackedPerson anonymize() {
+
+		setFirstName("###");
+		setLastName("###");
+		setDateOfBirth(null);
+		setPhoneNumber(null);
+		setMobilePhoneNumber(null);
+		setEmailAddress(null);
+
+		Address address = getAddress();
+		if (address != null) {
+			address.setStreet(null);
+			address.setHouseNumber(null);
+		}
+
+		getAccount().ifPresent(Account::anonymize);
+
+		return this;
+	}
+
+	/**
+	 * @since 1.4
+	 */
+	public TrackedPerson fillSampleData() {
+
+		firstName = defaultIfNull(firstName, "firstName");
+		lastName = defaultIfNull(lastName, "lastName");
+		dateOfBirth = defaultIfNull(dateOfBirth, LocalDate.now());
+		phoneNumber = defaultIfNull(phoneNumber, PhoneNumber.of("12345"));
+		mobilePhoneNumber = defaultIfNull(mobilePhoneNumber, PhoneNumber.of("67890"));
+		emailAddress = defaultIfNull(emailAddress, EmailAddress.of("email@address.xx"));
+
+		address = defaultIfNull(address, new Address());
+		address.setCity(defaultIfNull(address.getCity(), "city"));
+		address.setZipCode(defaultIfNull(address.getZipCode(), ZipCode.of("11111")));
+		address.setStreet(defaultIfNull(address.getStreet(), "street"));
+		address.setHouseNumber(defaultIfNull(address.getHouseNumber(), HouseNumber.of("111")));
 
 		return this;
 	}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -55,6 +55,11 @@ quarano.registration.expiration=24h
 quarano.anomalies.temperature-threshold=37.9f
 quarano.diary.tolerated-slot-count=1
 # quarano.diary.reminder.enable=false
+#quarano.date-time.delta = -6m-1d
+#quarano.gdpr.cases.anonymization-after=6m
+#quarano.gdpr.contacts.anonymization-after=16d
+#quarano.gdpr.occations.delete-occasions-after=6m
+#quarano.gdpr.occations.delete-visitors-after=16d
 
 quarano.cases.execute-contact-retro-for-contact-cases=false
 

--- a/backend/src/main/resources/db/migration/V1016.0__New_texts_Mannheim.sql
+++ b/backend/src/main/resources/db/migration/V1016.0__New_texts_Mannheim.sql
@@ -1,0 +1,1 @@
+-- see health department specific script

--- a/backend/src/main/resources/db/migration/V1020.0__New_email_texts_Cuxhaven.sql
+++ b/backend/src/main/resources/db/migration/V1020.0__New_email_texts_Cuxhaven.sql
@@ -1,0 +1,1 @@
+-- see health department specific script

--- a/backend/src/main/resources/db/migration/V1022__Add_contact_person_anonymized.sql
+++ b/backend/src/main/resources/db/migration/V1022__Add_contact_person_anonymized.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contact_people ADD anonymized bool DEFAULT false NOT NULL;

--- a/backend/src/test/java/quarano/department/GDPRAnonymizationJobIntegrationTests.java
+++ b/backend/src/test/java/quarano/department/GDPRAnonymizationJobIntegrationTests.java
@@ -1,0 +1,118 @@
+package quarano.department;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import quarano.QuaranoWebIntegrationTest;
+import quarano.actions.ActionItem;
+import quarano.actions.ActionItemRepository;
+import quarano.diary.DiaryEntry;
+import quarano.diary.DiaryEntryRepository;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@QuaranoWebIntegrationTest
+@RequiredArgsConstructor
+@SpringBootTest(properties = { "quarano.date-time.delta = -6m-1d" })
+class GDPRAnonymizationJobIntegrationTests {
+
+	Predicate<String> anonym = Pattern.compile("^[#\\s]*$").asPredicate();
+	Condition<Object> anonymized = new Condition<>(
+			it -> it == null || (it instanceof String && (it.equals("###") || anonym.test((String) it))),
+			"data is anonymized");
+
+	private final GDPRAnonymizationJob gdprAnonymizationJob;
+	private final TrackedCaseRepository cases;
+	private final @NonNull ActionItemRepository actions;
+	private final @NonNull DiaryEntryRepository diaries;
+
+	@Test // CORE-294
+	void testGDPRAnonymizationJob() {
+
+		var allCases = cases.findAll().map(TrackedCase::fillSampleData).toList();
+		cases.saveAll(allCases);
+
+		var allDiaries = StreamSupport.stream(diaries.findAll().spliterator(), false).map(DiaryEntry::fillSampleData)
+				.collect(Collectors.toList());
+		diaries.saveAll(allDiaries);
+
+		var allActions = actions.findAll().map(ActionItem::fillSampleData).toList();
+		actions.saveAll(allActions);
+
+		verifyCases(not(anonymized));
+		verifyDiaries(not(anonymized));
+		verifyActions(not(anonymized));
+
+		gdprAnonymizationJob.anonymizeCasesAndRelatedData();
+
+		verifyCases(anonymized);
+		verifyDiaries(anonymized);
+		verifyActions(anonymized);
+	}
+
+	private void verifyCases(Condition<Object> condition) {
+		assertThat(cases.findAll())
+				.filteredOn(it -> it.getTrackedPerson().getAccount().isPresent())
+				.filteredOn(it -> it.getQuestionnaire() != null)
+				.first()
+				.satisfies(it -> {
+
+					assertThat(it.getExtReferenceNumber()).is(condition);
+
+					assertThat(it.getTrackedPerson()).satisfies(p -> {
+
+						assertThat(p.getFullName()).is(condition);
+						assertThat(p.getDateOfBirth()).is(condition);
+						assertThat(p.getPhoneNumber()).is(condition);
+						assertThat(p.getMobilePhoneNumber()).is(condition);
+						assertThat(p.getEmailAddress()).is(condition);
+						assertThat(p.getAddress().getStreet()).is(condition);
+						assertThat(p.getAddress().getHouseNumber()).is(condition);
+					});
+
+					assertThat(it.getTrackedPerson().getAccount()).hasValueSatisfying(a -> {
+
+						assertThat(a.getFullName()).is(condition);
+						assertThat(a.getUsername()).is(condition);
+						assertThat(a.getEmail()).is(condition);
+						assertThat(a.getPassword().toString()).is(condition);
+					});
+
+					assertThat(it.getComments()).allSatisfy(c -> {
+
+						assertThat(c.getAuthor()).is(condition);
+						assertThat(c.getText()).is(condition);
+					});
+
+					assertThat(it.getQuestionnaire()).satisfies(q -> {
+
+						assertThat(q.getFamilyDoctor()).is(condition);
+						assertThat(q.getGuessedOriginOfInfection()).is(condition);
+						assertThat(q.getHasPreExistingConditionsDescription()).is(condition);
+						assertThat(q.getBelongToMedicalStaffDescription()).is(condition);
+						assertThat(q.getHasContactToVulnerablePeopleDescription()).is(condition);
+					});
+				});
+	}
+
+	private void verifyDiaries(Condition<Object> condition) {
+		assertThat(diaries.findAll()).first().satisfies(it -> assertThat(it.getNote()).is(condition));
+	}
+
+	private void verifyActions(Condition<Object> condition) {
+		assertThat(actions.findAll()).first()
+				.satisfies(it -> assertThat(it.getDescription().getArguments()).allMatch(condition::matches));
+	}
+}

--- a/backend/src/test/java/quarano/occasion/GDPRDeleteJobIntegrationTests.java
+++ b/backend/src/test/java/quarano/occasion/GDPRDeleteJobIntegrationTests.java
@@ -1,0 +1,108 @@
+package quarano.occasion;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.RequiredArgsConstructor;
+import quarano.QuaranoWebIntegrationTest;
+import quarano.core.QuaranoDateTimeProvider;
+import quarano.department.TrackedCaseDataInitializer;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@QuaranoWebIntegrationTest
+@RequiredArgsConstructor
+class GDPRDeleteJobIntegrationTests {
+
+	private final OccasionManagement occasions;
+	private final QuaranoDateTimeProvider dateTimeProvider;
+	private final GDPRDeleteJob gdprDeleteJob;
+	private final LocalDate today = LocalDate.now();
+
+	@Test // CORE-294
+	void testDeleteOccasions() {
+
+		dateTimeProvider.setDelta(Period.ofMonths(-6));
+
+		createOccasion("AAA", "AA", "A", "B", "C");
+
+		dateTimeProvider.setDelta(Period.ofMonths(-6).minusDays(1));
+
+		createOccasion("DDD", "DD", "D", "E", "F");
+
+		dateTimeProvider.reset();
+
+		var all = occasions.findAll();
+
+		// one extra element from data initialization
+		assertThat(all).hasSize(3).element(2).satisfies(it -> {
+			assertThat(it.getTitle()).isEqualTo("DDD");
+			assertThat(it.getVisitorGroups()).singleElement().satisfies(it2 -> {
+				assertThat(it2.getVisitors()).hasSize(3);
+			});
+		});
+
+		gdprDeleteJob.deleteOccasions();
+
+		all = occasions.findAll();
+
+		assertThat(all).hasSize(2).noneMatch(it -> it.getTitle().equals("DDD"));
+	}
+
+	@Test // CORE-294
+	void testDeleteVisitors() {
+
+		dateTimeProvider.setDelta(Period.ofDays(-16));
+
+		createOccasion("AAA", "AA", "A", "B", "C");
+
+		dateTimeProvider.setDelta(Period.ofDays(-17));
+
+		createOccasion("DDD", "DD", "D", "E", "F");
+
+		dateTimeProvider.reset();
+
+		var all = occasions.findAll();
+
+		// one extra element from data initialization
+		assertThat(all).hasSize(3).element(2).satisfies(it -> {
+			assertThat(it.getTitle()).isEqualTo("DDD");
+			assertThat(it.getVisitorGroups()).singleElement().satisfies(it2 -> {
+				assertThat(it2.getVisitors()).hasSize(3);
+			});
+		});
+
+		gdprDeleteJob.deleteVisitors();
+
+		all = occasions.findAll();
+
+		assertThat(all).hasSize(3).element(2).satisfies(it -> {
+			assertThat(it.getTitle()).isEqualTo("DDD");
+			assertThat(it.getVisitorGroups()).isEmpty();
+		});
+	}
+
+	private void createOccasion(String title, String locationName, String... visitorNames) {
+
+		var event = occasions.createOccasion(title, today.atStartOfDay(), today.plusDays(1).atStartOfDay(),
+				TrackedCaseDataInitializer.TRACKED_CASE_MARKUS).orElseThrow();
+
+		var visitors = Arrays.stream(visitorNames)
+				.map(it -> new Visitor(it.toUpperCase(), it.toLowerCase(), null))
+				.collect(Collectors.toList());
+
+		var visitorGroup = new VisitorGroup(today.atStartOfDay(), event.getOccasionCode())
+				.setLocationName(locationName)
+				.setVisitors(visitors);
+
+		occasions.registerVisitorGroupForEvent(event.getOccasionCode(), visitorGroup);
+	}
+}

--- a/backend/src/test/java/quarano/tracking/GDPRAnonymizationJobIntegrationTests.java
+++ b/backend/src/test/java/quarano/tracking/GDPRAnonymizationJobIntegrationTests.java
@@ -1,0 +1,61 @@
+package quarano.tracking;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.RequiredArgsConstructor;
+import quarano.QuaranoWebIntegrationTest;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * @author Jens Kutzsche
+ * @since 1.4
+ */
+@QuaranoWebIntegrationTest
+@RequiredArgsConstructor
+@SpringBootTest(properties = { "quarano.date-time.delta = -17d" })
+class GDPRAnonymizationJobIntegrationTests {
+
+	Predicate<String> anonym = Pattern.compile("^[#\\s]*$").asPredicate();
+	Condition<Object> anonymized = new Condition<>(
+			it -> it == null || (it instanceof String && (it.equals("###") || anonym.test((String) it))),
+			"data is anonymized");
+
+	private final GDPRAnonymizationJob gdprAnonymizationJob;
+	private final ContactPersonRepository contacts;
+
+	@Test // CORE-294
+	void testGDPRAnonymizationJob() {
+
+		var allContacts = contacts.findAll().map(ContactPerson::fillSampleData).toList();
+
+		contacts.saveAll(allContacts);
+
+		verifyContacts(not(anonymized));
+
+		gdprAnonymizationJob.anonymizeContactsAndRelatedData();
+
+		verifyContacts(anonymized);
+	}
+
+	private void verifyContacts(Condition<Object> condition) {
+		assertThat(contacts.findAll())
+				.first()
+				.satisfies(it -> {
+
+					assertThat(it.getFullName()).is(condition);
+					assertThat(it.getPhoneNumber()).is(condition);
+					assertThat(it.getMobilePhoneNumber()).is(condition);
+					assertThat(it.getEmailAddress()).is(condition);
+					assertThat(it.getAddress().getStreet()).is(condition);
+					assertThat(it.getAddress().getHouseNumber()).is(condition);
+					assertThat(it.getIdentificationHint()).is(condition);
+					assertThat(it.getRemark()).is(condition);
+				});
+	}
+}


### PR DESCRIPTION
The idea with GDPR implementation is to only overwrite the personal data
(### for text makes anonymization clear or Null for other data types)
and not delete the whole records. By anonymizing, we avoid some problems
with dependencies between data that have to be taken into account in
different places if anything is to be deleted. Besides, the possibility
for statistical analysis e.g. on the level of the postal code or the
city remains.

The following three domains in the data are handled separately as
follows:

1. Once a day during the night, a job runs that deletes all occasions
that were created more than 6 months ago. Furthermore, for all occasions
created more than 16 days ago, the associated visitors are deleted. This
data is so loosely connected to the rest of the data model that deletion
is easy to implement.

2. Once a day during the night, a job runs that anonymizes (for what
exactly see later overview) all contacts (not contact persons or contact
cases) that were created more than 16 days ago. Only from non-anonymized
contacts cases are created, in case of later conversion.

3. Once a day during the night, a job runs that anonymizes all cases
created more than 6 months ago. Thereby all relevant referenced data
(e.g. account, person, ...) are anonymized (what exactly see later
overview). Anonymized cases are no longer included in the overviews and
exports. Therefore the cases get a corresponding status.

When to delete is adjustable.

To enable tests of these time-related functions, it is now possible to
specify a delta for the creation and modification time of the data via
the property quarano.date-time.delta. This only works in non-production
environments.